### PR TITLE
[front] 食材管理画面の実装

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,9 @@
     <title><%= htmlWebpackPlugin.options.title %></title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@latest/css/materialdesignicons.min.css">
+    <style>
+      * { margin: 0px; padding: 0px; }
+    </style>
   </head>
   <body>
     <noscript>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,19 +1,20 @@
 <template>
-  <v-app>
-    <div class="root">
-      <KakeiboooAppBar/>
-    </div>
-  </v-app>
+  <div class="root">
+    <KakeiboooAppBar/>
+    <FoodStaffView/>
+  </div>
 </template>
 
 <script lang="ts">
 import { Vue, Component } from 'vue-property-decorator';
 
-import KakeiboooAppBar from '@/components/KakeiboooAppBar.vue';
+import KakeiboooAppBar from '@/components/appbar/KakeiboooAppBar.vue';
+import FoodStaffView from '@/views/FoodStaffView.vue';
 
 @Component({
   components: {
     KakeiboooAppBar,
+    FoodStaffView
   }
 })
 export default class App extends Vue {};
@@ -27,7 +28,7 @@ export default class App extends Vue {};
   width: 100%;
   height: 100%;
   display: flex;
-  flex-flow: "column";
+  flex-flow: column;
   background: #FFFFFF;
 }
 </style>

--- a/src/components/appbar/KakeiboooAppBar.vue
+++ b/src/components/appbar/KakeiboooAppBar.vue
@@ -6,17 +6,19 @@
             <div class="app_title">KaKeiBooo</div>
         </div>
         <!-- メニュータブ部分 -->
-        <KakeiboooTab :tabItems="tabItems" v-model="value">
-            <template slot-scope="{ tabItems, onTabChange, value }">
-            <KakeiboooTabItem
-                v-for="(tabItem, index) in tabItems"
-                :key="index"
-                :tabItem="tabItem"
-                :isSelected="value === tabItem.label"
-                @change="ontabchange"
-            />
-            </template>
-        </KakeiboooTab>
+        <div class="tab_area">
+            <KakeiboooTab :tabItems="tabItems" v-model="value">
+                <template slot-scope="{ tabItems, onTabChange, value }">
+                <KakeiboooTabItem
+                    v-for="(tabItem, index) in tabItems"
+                    :key="index"
+                    :tabItem="tabItem"
+                    :isSelected="value === tabItem.label"
+                    @change="ontabchange"
+                />
+                </template>
+            </KakeiboooTab>
+        </div>
         <!-- ユーザアカウント部分 -->
         <div class="account_area">
            <v-avatar width="40" height="40"><img src="@/assets/user_account.png"></v-avatar>
@@ -28,8 +30,8 @@
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
 
-import KakeiboooTab from '@/components/KakeiboooTab.vue';
-import KakeiboooTabItem from '@/components/KakeiboooTabItem.vue';
+import KakeiboooTab from '@/components/common/KakeiboooTab.vue';
+import KakeiboooTabItem from '@/components/common/KakeiboooTabItem.vue';
 
 export type tabCategory = '家計簿' | '食費管理' | '食材管理';
 
@@ -52,24 +54,29 @@ export default class KakeiboooAppBar extends Vue {
         this.value = selected;
     }
 
+    // タブ要素一覧
+    private tabItems: {label: tabCategory, icon: string}[] = [
+        {label: '家計簿', icon: 'mdi-square-edit-outline'},
+        {label: '食費管理', icon: 'mdi-cart'},
+        {label: '食材管理', icon: 'mdi-one-up'}
+    ];
     /**
      * タブ要素一覧を取得
      */
-    get tabItems(): {label: tabCategory, icon: string}[] {
-        return [
-            {label: '家計簿', icon: 'mdi-square-edit-outline'},
-            {label: '食費管理', icon: 'mdi-cart'},
-            {label: '食材管理', icon: 'mdi-one-up'}
-        ];
-    };
+    // get tabItems(): {label: tabCategory, icon: string}[] {
+    //     return [
+    //         {label: '家計簿', icon: 'mdi-square-edit-outline'},
+    //         {label: '食費管理', icon: 'mdi-cart'},
+    //         {label: '食材管理', icon: 'mdi-one-up'}
+    //     ];
+    // };
 }
 </script>
 
 <style scoped>
 .appbar_root {
-    height: 90px;
+    height: 70px;
     width: 100%;
-    padding: 10px;
     background: #FFFFFF;
     display: flex;
     justify-content: space-around;
@@ -110,5 +117,12 @@ export default class KakeiboooAppBar extends Vue {
     font-size: 18px;
     font-weight: 700;
     color: #616161;
+}
+.tab_area {
+    width: 650px;
+    height: 100%;
+    padding: 10px;
+    display: flex;
+    align-items: center;
 }
 </style>

--- a/src/components/common/KakeiboooTab.vue
+++ b/src/components/common/KakeiboooTab.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="tab_area">
+    <div class="kakeibooo_tab">
         <slot v-bind="slotProps" />
     </div>
 </template>
@@ -7,8 +7,8 @@
 <script lang="ts">
 import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
 
-import KakeiboooTabItem from '@/components/KakeiboooTabItem.vue';
-import { tabCategory } from '@/components/KakeiboooAppBar.vue';
+import KakeiboooTabItem from '@/components/common/KakeiboooTabItem.vue';
+import { tabCategory } from '@/components/appbar/KakeiboooAppBar.vue';
 
 @Component({
     components: {
@@ -45,17 +45,8 @@ export default class KakeiboooTab extends Vue {
 </script>
 
 <style scoped>
-.tab_root {
+.kakeibooo_tab {
     width: 100%;
     height: 100%;
-    display: flex;
-    /* justify-content: space-between; */
-}
-.tab_area {
-    width: 650px;
-    height: 100%;
-    padding: 10px;
-    display: flex;
-    align-items: center;
 }
 </style>

--- a/src/components/common/KakeiboooTabItem.vue
+++ b/src/components/common/KakeiboooTabItem.vue
@@ -3,10 +3,10 @@
         :ripple="{ class: 'white--text' }"
         :class="{'active_tab': isSelected}"
         @click="tabClick"
-        width="200"
+        width="33%"
         height="100%"
         elevation="0"
-        color="#FFFFFF" tile
+        tile text
     >
         <div :class="{'active_category': isSelected}" class="tab_category">
             <v-icon class="tab_icon">{{tabItem.icon}}</v-icon>
@@ -16,7 +16,7 @@
 </template>
 <script lang="ts">
 import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
-import { tabCategory } from '@/components/KakeiboooAppBar.vue';
+import { tabCategory } from '@/components/appbar/KakeiboooAppBar.vue';
 
 @Component({})
 export default class KakeiboooTabItem extends Vue {
@@ -39,7 +39,7 @@ export default class KakeiboooTabItem extends Vue {
 
 <style scoped>
 .tab_item {
-    width: 200px;
+    width: 30%;
     border-bottom: 3px solid #FFFFFF;
 }
 .tab_category {
@@ -49,7 +49,7 @@ export default class KakeiboooTabItem extends Vue {
     display: flex;
 }
 .tab_icon {
-    margin-right: 10px;
+    margin-right: 5px;
 }
 .active_tab {
     border-bottom: 3px solid #FFD600 !important;

--- a/src/components/foodstaff/FoodStaffList.vue
+++ b/src/components/foodstaff/FoodStaffList.vue
@@ -1,0 +1,34 @@
+<template>
+    <div>
+        <slot v-bind="slotProps" />
+    </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+
+import FoodStaffListItem from '@/components/foodstaff/FoodStaffListItem.vue';
+
+@Component({
+    components: {
+        FoodStaffListItem
+    }
+})
+export default class FoodStaffList extends Vue {
+    @Prop({})
+    private listItems!: {name: string, count: number, unit:string, category: string, subCategory?:string}[];
+
+    get slotPlops() {
+        return {
+            listItems: this.$props.listItems,
+            onclick: this.onclick
+        }
+    }
+
+    onclick(selected: string) {
+    }
+}
+</script>
+
+<style scoped>
+</style>

--- a/src/components/foodstaff/FoodStaffListItem.vue
+++ b/src/components/foodstaff/FoodStaffListItem.vue
@@ -1,0 +1,52 @@
+<template>
+    <div class="list_item_root">
+        <div class="list_name">{{listItem.name}}</div>
+        <div class="list_count">{{listItem.count}} ml</div>
+        <div class="list_action">
+            <v-btn @click="onClick" class="list_action_button" color="#FF8A80" elevation="0" height="30" width="75" small>買った！</v-btn>
+            <v-btn @click="onClick" class="list_action_button" color="#80CBC4" elevation="0" height="30" width="75" small>使った！</v-btn>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { Vue, Prop, Component } from 'vue-property-decorator';
+
+@Component({})
+export default class FoodStaffListItem extends Vue {
+    @Prop({})
+    listItem!: {name: string, count: number};
+
+    onClick() {
+    }
+
+}
+</script>
+
+<style scoped>
+.list_item_root {
+    padding: 5px;
+    color: #616161;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: space-around;
+    border-bottom: 1px dashed #E0E0E0;
+}
+.list_name {
+    width: 150px;
+}
+.list_count {
+    width: 100px;
+}
+.list_action {
+    width: 200px;
+    display: flex;
+    justify-content: space-evenly;
+}
+.list_action_button {
+    color: #FFFFFF;
+    font-size: 14px;
+    font-weight: 700;
+}
+</style>

--- a/src/components/foodstaff/FoodStaffRecorder.vue
+++ b/src/components/foodstaff/FoodStaffRecorder.vue
@@ -1,0 +1,241 @@
+<template>
+    <div class="food_staff_recorder">
+        <div class="preserved_place_area">
+            <!-- 冷凍庫 -->
+            <div class="preserved_place_category">
+                <div class="preserved_place_label">
+                    <v-icon class="preserved_place_icon" color="#616161">mdi-fridge-top</v-icon>
+                    冷凍庫
+                </div>
+                <div class="food_staff_list" style="overflow: scroll;">
+                    <FoodStaffList :listItems="fridgeTop">
+                        <template slot-scope="{listItems, onclick}">
+                        <FoodStaffListItem
+                            v-for="(listItem, index) in fridgeTop"
+                            :key="index"
+                            :listItem="listItem"
+                            @click="onclick"
+                        />
+                        </template>
+                    </FoodStaffList>
+                </div>
+            </div>
+            <!-- 冷蔵庫 -->
+            <div class="preserved_place_category">
+                <div class="preserved_place_label">
+                    <v-icon class="preserved_place_icon" color="#616161">mdi-fridge-bottom</v-icon>
+                    冷蔵庫
+                </div>
+                <div class="food_staff_list" style="overflow: scroll;">
+                    <div class="small_category_tab">
+                        <KakeiboooTab :tabItems="tabItems" v-model="value">
+                            <template slot-scope="{ tabItems, onTabChange, value }">
+                            <KakeiboooTabItem
+                                v-for="(tabItem, index) in tabItems"
+                                :key="index"
+                                :tabItem="tabItem"
+                                :isSelected="value === tabItem.label"
+                                @change="ontabchange"
+                            />
+                            </template>
+                        </KakeiboooTab>
+                    </div>
+                    <div class="food_staff_list_with_tab">
+                        <FoodStaffList :listItems="fridgeBottom">
+                            <template slot-scope="{listItems, onclick}">
+                            <FoodStaffListItem
+                                v-for="(listItem, index) in fridgeBottom"
+                                :key="index"
+                                :listItem="listItem"
+                                @click="onclick"
+                            />
+                            </template>
+                        </FoodStaffList>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="preserved_place_area">
+                <!-- 調味料 -->
+                <div class="preserved_place_category">
+                    <div class="preserved_place_label">
+                        <v-icon class="preserved_place_icon" color="#616161">mdi-shaker-outline</v-icon>
+                        調味料
+                    </div>
+                    <div class="food_staff_list" style="overflow: scroll;">
+                        <FoodStaffList :listItems="seasoning">
+                            <template slot-scope="{listItems, onclick}">
+                            <FoodStaffListItem
+                                v-for="(listItem, index) in seasoning"
+                                :key="index"
+                                :listItem="listItem"
+                                @click="onclick"
+                            />
+                            </template>
+                        </FoodStaffList>
+                    </div>
+                </div>
+                <!-- 保存食 -->
+                <div class="preserved_place_category">
+                    <div class="preserved_place_label">
+                        <v-icon class="preserved_place_icon" color="#616161">mdi-noodles</v-icon>
+                        保存食
+                    </div>
+                    <div class="food_staff_list" style="overflow:scroll;">
+                        <FoodStaffList :listItems="preserved">
+                            <template slot-scope="{listItems, onclick}">
+                            <FoodStaffListItem
+                                v-for="(listItem, index) in preserved"
+                                :key="index"
+                                :listItem="listItem"
+                                @click="onclick"
+                            />
+                            </template>
+                        </FoodStaffList>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import FoodStaffList from '@/components/foodstaff/FoodStaffList.vue';
+import FoodStaffListItem from '@/components/foodstaff/FoodStaffListItem.vue';
+import KakeiboooTab from '@/components/common/KakeiboooTab.vue';
+import KakeiboooTabItem from '@/components/common/KakeiboooTabItem.vue';
+import { foodCountUnit } from '@/components/foodstaff/FoodStaffRegister.vue';
+
+type tabItemLabel = '野菜' | '残りもの' | 'その他';
+type foodStaffDetails = {
+    name: string;
+    count: number;
+    unit: foodCountUnit;
+    category: 'fridge-top' | 'fridge-bottom' | 'seasoning' | 'preserved';
+    subCategory?: 'vegetables' | 'leftovers'| 'others';
+}
+
+@Component({
+    components: {
+        FoodStaffList,
+        FoodStaffListItem,
+        KakeiboooTab,
+        KakeiboooTabItem
+    }
+})
+export default class FoodStaffRecorder extends Vue {
+    private value: tabItemLabel = '野菜';
+
+    private tabItems: {label: tabItemLabel, icon: string}[] = [
+        {label: '野菜', icon: 'mdi-corn'},
+        {label: '残りもの', icon: 'mdi-diamond-stone'},
+        {label: 'その他', icon: 'mdi-flower'}
+    ];
+
+    private fridgeTop: foodStaffDetails[] = [];
+    private fridgeBottom: foodStaffDetails[] = [];
+    private seasoning: foodStaffDetails[] = [];
+    private preserved: foodStaffDetails[] = [];
+
+    // TODO サンプルなのでのちのち消す → 本当はmount時にSVから取得する
+    private foodStaffSample: foodStaffDetails[] = [
+        {name: "豚こま", count: 100, unit:'g', category: 'fridge-top'},
+        {name: "鶏むね", count: 150, unit:'g', category: 'fridge-top'},
+        {name: "あいびき肉", count: 200, unit:'g', category: 'fridge-top'},
+        {name: "枝豆", count: 1, unit:'袋', category: 'fridge-top'},
+        {name: "大根", count: 0.2, unit: '本', category: 'fridge-bottom', subCategory: 'vegetables'},
+        {name: "人参", count: 0.5, unit: '本', category: 'fridge-bottom', subCategory: 'vegetables'},
+        {name: "じゃがいも", count: 3, unit: '個', category: 'fridge-bottom', subCategory: 'vegetables'},
+        {name: "白菜", count: 1, unit: '本', category: 'fridge-bottom', subCategory: 'vegetables'},
+        {name: "きゅうり", count: 2, unit: '個', category: 'fridge-bottom', subCategory: 'vegetables'},
+        {name: "肉じゃが", count: 100, unit: 'g', category: 'fridge-bottom', subCategory: 'leftovers'},
+        {name: "水菜サラダ", count: 100, unit: 'g', category: 'fridge-bottom', subCategory: 'leftovers'},
+        {name: "カレー", count: 150, unit: 'g', category: 'fridge-bottom', subCategory: 'leftovers'},
+        {name: "ルイボスティー", count: 500, unit: 'ml', category: 'fridge-bottom', subCategory: 'others'},
+        {name: "卵", count: 5, unit: '個', category: 'fridge-bottom', subCategory: 'others'},
+        {name: "稲荷の皮", count: 3, unit: '個', category: 'fridge-bottom', subCategory: 'others'},
+        {name: "しお", count: 1, unit:'本', category: 'seasoning'},
+        {name: "パルスイート", count: 100, unit:'ml', category: 'seasoning'},
+        {name: "コンソメ", count: 400, unit:'g', category: 'seasoning'},
+        {name: "カップ麺", count: 10, unit: '個', category: 'preserved'},
+        {name: "パスタ", count: 1, unit: '個', category: 'preserved'},
+        {name: "うどん", count: 4, unit: '個', category: 'preserved'},
+    ];
+
+     convertNameToValue(): string {
+        if(this.value === '野菜') {
+            return 'vegetables';
+        } else if(this.value === '残りもの') {
+            return 'leftovers'
+        } else {
+            return 'others';
+        }
+    }
+
+    mounted() {
+        const fridgeBottomLabel = this.convertNameToValue();
+        this.fridgeTop = this.foodStaffSample.filter(staff => staff.category === 'fridge-top');
+        this.fridgeBottom = this.foodStaffSample.filter(staff => staff.category === 'fridge-bottom' && staff.subCategory === fridgeBottomLabel);
+        this.seasoning = this.foodStaffSample.filter(staff => staff.category === 'seasoning');
+        this.preserved = this.foodStaffSample.filter(staff => staff.category === 'preserved');
+    }
+
+    /**
+     * 選択中のタブを切り替え
+     */
+    ontabchange(selected: tabItemLabel) {
+        this.value = selected;
+        this.fridgeBottom = this.foodStaffSample.filter(staff => staff.subCategory === this.convertNameToValue());
+    }
+
+    onclick(seleced: string) {
+    }
+}
+</script>
+
+<style scoped>
+@import url('https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@100;300;400;500;700;800;900&display=swap');
+
+.food_staff_recorder {
+    font-family: 'M PLUS Rounded 1c', sans-serif;
+    display: flex;
+    flex-direction: row;
+}
+.preserved_place_area {
+    width: 50%;
+    height: 600px; /** 仮おき */
+    padding: 10px;
+    background: #FAFAFA;
+}
+.preserved_place_category {
+    width: 100%;
+    height:50%;
+    margin-bottom: 10px;
+}
+.preserved_place_label {
+    font-weight: 700;
+    font-size: 24px;
+    color: #616161;
+    text-align: center;
+}
+.preserved_place_icon {
+    margin-right: 5px;
+}
+.food_staff_list {
+    height: 250px;
+    border-radius: 8px;
+    border: 3px solid #E0E0E0;
+    padding: 5px;
+    margin: 0px 10px 10px 10px;
+}
+.food_staff_list_with_tab {
+    height:165px;
+    margin-top:10px;
+    overflow:scroll;
+}
+.small_category_tab {
+    height: 40px;
+    background: #FAFAFA;
+}
+</style>

--- a/src/components/foodstaff/FoodStaffRecorder.vue
+++ b/src/components/foodstaff/FoodStaffRecorder.vue
@@ -223,6 +223,7 @@ export default class FoodStaffRecorder extends Vue {
     margin-right: 5px;
 }
 .food_staff_list {
+    background: #FFFFFF;
     height: 250px;
     border-radius: 8px;
     border: 3px solid #E0E0E0;
@@ -236,6 +237,6 @@ export default class FoodStaffRecorder extends Vue {
 }
 .small_category_tab {
     height: 40px;
-    background: #FAFAFA;
+    background: #FFFFFF;
 }
 </style>

--- a/src/components/foodstaff/FoodStaffRegister.vue
+++ b/src/components/foodstaff/FoodStaffRegister.vue
@@ -1,0 +1,134 @@
+<template>
+    <v-app>
+        <div class="food_staff_register">
+            <!-- 買った品名 -->
+            <div class="bought_food">
+                <div class="bought_food_label">買ったもの</div>
+                <div><v-text-field color="#E0E0E0" dense outlined flat solo /></div>
+            </div>
+            <!-- 買った個数-->
+            <div class="bought_food">
+                <div class="bought_food_label">個数</div>
+                <div id="bought_food_count">
+                    <div class="food_count"><v-text-field color="#E0E0E0" dense outlined solo flat clearable /></div>
+                    <div class="food_unit">
+                        <v-select
+                            style="color: 'white"
+                            item-color="yellow accent-4"
+                            v-model="model"
+                            :items="items"
+                            color="#E0E0E0"
+                            dense
+                            outlined
+                            solo
+                            flat
+                        />
+                    </div>
+                </div>
+            </div>
+            <div id="preserve_place_selection">
+                <div class="bought_food_label">保存場所</div>
+                <!-- 保存場所（大分類）-->
+                <div id="large_class_selection">
+                    <v-btn-toggle v-model="largeClassSelection" background-color="#FAFAFA" color="#FFD600" mandatory>
+                        <v-btn><v-icon color="#616161">mdi-fridge-top</v-icon></v-btn>
+                        <v-btn><v-icon color="#616161">mdi-fridge-bottom</v-icon></v-btn>
+                        <v-btn><v-icon color="#616161">mdi-shaker-outline</v-icon></v-btn>
+                        <v-btn><v-icon color="#616161">mdi-noodles</v-icon></v-btn>
+                    </v-btn-toggle>
+                </div>
+                <!-- 保存場所（小分類）-->
+                <div v-show="largeClassSelection === 1" id="small_class_selection">
+                    <v-btn-toggle v-model="smallClassSelection" background-color="#FAFAFA" color="#FFD600">
+                        <v-btn><v-icon color="#616161">mdi-corn</v-icon></v-btn>
+                        <v-btn><v-icon color="#616161">mdi-diamond-stone</v-icon></v-btn>
+                        <v-btn><v-icon color="#616161">mdi-flower</v-icon></v-btn>
+                    </v-btn-toggle>
+                </div>
+            </div>
+            <!-- 登録ボタン -->
+            <div id="register_food_staff">
+                <v-btn color="#FFD600" elevation="0" width="100%" height="50">
+                    <div id="register_button_label">食材を登録!</div>
+                </v-btn>
+            </div>
+        </div>
+    </v-app>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop} from 'vue-property-decorator';
+
+export type foodCountUnit = '個' | '本' | '袋' | '束' | '缶' | 'g' | 'ml';
+
+@Component({})
+export default class FoodStaffRegister extends Vue {
+    private model: foodCountUnit = '個';
+    private items: foodCountUnit[] = ['個', '本', '袋', '束', '缶', 'g', 'ml'];
+    private largeClassSelection: number = 0;
+    private smallClassSelection: number = 1;
+}
+</script>
+
+<style scoped>
+@import url('https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@100;300;400;500;700;800;900&display=swap');
+
+.food_staff_register {
+    font-family: 'M PLUS Rounded 1c', sans-serif;
+}
+
+.v-text-field >>> input {
+    color: #616161 !important;
+    font-weight: 700;
+    font-size: 18px;
+}
+.bought_food {
+    height: 110px;
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-evenly;
+}
+.bought_food_label {
+    margin-bottom: 5px;
+    font-weight: 700;
+    color: #9E9E9E;
+    font-size: 18px;
+}
+#bought_food_count {
+    display: flex;
+    justify-content: space-evenly;
+}
+.food_count {
+    width: 65%;
+}
+.food_unit {
+    width: 35%;
+    margin-left: 10px;
+}
+#preserve_place_selection {
+    height: 250px;
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+}
+#large_class_selection {
+    margin: 10px 0px;
+}
+#small_class_selection {
+    margin: 10px 0px;
+    padding: 10px 0px;
+}
+#register_food_staff {
+    height: 100px;
+    text-align: center;
+    display: flex;
+    align-items: center;
+    margin: 10px;
+}
+#register_button_label {
+    font-size: 24px;
+    font-weight: 700;
+    color: #FFFFFF;
+}
+</style>

--- a/src/views/FoodStaffView.vue
+++ b/src/views/FoodStaffView.vue
@@ -1,0 +1,55 @@
+<template>
+    <v-app>
+        <div class="food_staff_view_root">
+            <!-- 買ったもの登録エリア -->
+            <div class="register_area">
+                <FoodStaffRegister/>
+            </div>
+            <!-- 冷凍庫/冷蔵庫エリア -->
+            <div class="recorder_area">
+                <FoodStaffRecorder/>
+            </div>
+        </div>
+    </v-app>
+</template>
+
+<script lang="ts">
+import { Vue, Component } from 'vue-property-decorator';
+
+import FoodStaffRegister from '@/components/foodstaff/FoodStaffRegister.vue';
+import FoodStaffRecorder from '@/components/foodstaff/FoodStaffRecorder.vue';
+
+@Component({
+    components: {
+        FoodStaffRegister,
+        FoodStaffRecorder,
+    }
+})
+export default class FoodStaffView extends Vue {
+}
+</script>
+
+<style scoped>
+@import url('https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@100;300;400;500;700;800;900&display=swap');
+
+.food_staff_view_root {
+    font-family: 'M PLUS Rounded 1c', sans-serif;
+    width: 100%;
+    height: 600px; /** 仮おき */
+    padding: 10px;
+    border-top: 2px solid #E0E0E0;
+    display: flex;
+    flex-direction: row;
+}
+.register_area {
+    width: 20%;
+    height: 600px; /** 仮おき */
+    padding: 10px;
+    border-right: 2px solid #E0E0E0;
+    margin-right: 10px;
+}
+
+.recorder_area {
+    width:80%;
+}
+</style>


### PR DESCRIPTION
### 実装後の画面

<img width="1427" alt="スクリーンショット 2020-05-24 18 38 55" src="https://user-images.githubusercontent.com/51043054/82750824-ddaaf500-9ded-11ea-94a0-c99d734f3d84.png">

### 特記事項・雑感
* クリックイベントはノータッチ（貫通実装でまとめてやる）
* トグルボタンも自作できたらよりよい

