### PR TITLE
[front/server] 食材管理画面の「買ったよ」「使ったよ」実装

### DIFF
--- a/client/src/apis/foodStaffApi.ts
+++ b/client/src/apis/foodStaffApi.ts
@@ -12,10 +12,10 @@ export const post = async (requestBody: {}) => {
     return await axios.post('http://localhost:3000/foodstaffs', requestBody);
 };
 
-export const updateById = async () => {
-
+export const updateById = async (id: number, requestBody: {}) => {
+    return await axios.put('http://localhost:3000/foodstaffs/' + id, requestBody)
 };
 
-export const deleteById = async () => {
-
+export const deleteById = async (id: number) => {
+    return await axios.delete('http://localhost:3000/foodstaffs/' + id);
 };

--- a/client/src/components/foodstaff/FoodStaffListItem.vue
+++ b/client/src/components/foodstaff/FoodStaffListItem.vue
@@ -3,8 +3,167 @@
         <div class="list_name">{{listItem.staffName}}</div>
         <div class="list_count">{{listItem.staffCount}} {{listItem.unit}}</div>
         <div class="list_action">
-            <v-btn @click="onClick" class="list_action_button" color="#FF8A80" elevation="0" height="30" width="75" small>買った！</v-btn>
-            <v-btn @click="onClick" class="list_action_button" color="#80CBC4" elevation="0" height="30" width="75" small>使った！</v-btn>
+            <v-btn
+                @click="isOpenBuyDlg=true"
+                class="list_action_button"
+                color="#FF8A80"
+                elevation="0"
+                height="30"
+                width="75"
+                small
+            >
+                買った！
+            </v-btn>
+            <v-btn
+                @click="isOpenUseDlg=true"
+                class="list_action_button"
+                color="#80CBC4"
+                elevation="0"
+                height="30"
+                width="75"
+                small
+            >
+                使った！
+            </v-btn>
+
+            <!-- 「買ったよ！」DLG -->
+            <v-dialog v-model="isOpenBuyDlg" width="600" height="360">
+                <v-card>
+                    <div class="dialog-title red accent-1">
+                        <v-card-title class="red accent-1">「買ったよ！」</v-card-title>
+                        <v-btn
+                            @click="closeDialog"
+                            icon
+                            color="#FFFFFF"
+                            style="margin-right:10px;"
+                        >
+                            <v-icon>mdi-close</v-icon>
+                        </v-btn>
+                    </div>
+                    <v-card-text class="card-body">
+                        <v-container class="card-container">
+                            <div class="card-title">
+                                {{listItem.staffName}} を 何{{listItem.unit}} 買いましたか？
+                            </div>
+                             <div class="card-input">
+                                <div class="card-input-count">
+                                    <v-text-field
+                                        v-model="count"
+                                        color="#E0E0E0"
+                                        height="100"
+                                        width="200"
+                                        :rules="[isInputMinus]"
+                                        outlined
+                                        flat
+                                        solo
+                                    />
+                                </div>
+                                <div class="card-input-unit">{{listItem.unit}}</div>
+                                <div class="add-sub-part">
+                                    <v-btn @click="count++" icon><v-icon>mdi-plus</v-icon></v-btn>
+                                    <v-btn @click="count--" icon><v-icon>mdi-minus</v-icon></v-btn>
+                                </div>
+                             </div>
+                             <div class="card-input-helper">
+                                 <v-btn @click="addBuyCount(10)"  class="helper-button" color="#616161" text>+10</v-btn>
+                                 <v-btn @click="addBuyCount(50)"  class="helper-button" color="#616161" text>+50</v-btn>
+                                 <v-btn @click="addBuyCount(100)" class="helper-button" color="#616161" text>+100</v-btn>
+                            </div>
+                        </v-container>
+                    </v-card-text>
+                    <v-divider></v-divider>
+                    <v-card-actions class="card-action">
+                        <v-btn
+                            width="100"
+                            :disabled="canClickOkButton()"
+                            color="red accent-1"
+                            class="dialog-action-button"
+                            elevation="0"
+                            @click="closeDialogWithUpdate('buy')"
+                        >
+                            OK
+                        </v-btn>
+                        <v-btn
+                            width="100"
+                            color="red accent-1"
+                            class="dialog-action-button"
+                            text
+                            @click="closeDialog"
+                        >
+                            キャンセル
+                        </v-btn>
+                    </v-card-actions>
+                </v-card>
+            </v-dialog>
+
+            <!-- 「使ったよ！」DLG -->
+            <v-dialog v-model="isOpenUseDlg" width="600" height="360">
+                <v-card>
+                    <div class="dialog-title teal lighten-3">
+                        <v-card-title class="teal lighten-3">「使ったよ！」</v-card-title>
+                        <v-btn
+                            @click="closeDialog"
+                            icon
+                            color="#FFFFFF"
+                            style="margin-right:10px;"
+                        >
+                            <v-icon>mdi-close</v-icon>
+                        </v-btn>
+                    </div>
+                    <v-card-text class="card-body">
+                        <v-container class="card-container">
+                            <div class="card-title">
+                                {{listItem.staffName}} を 何{{listItem.unit}} 使いましたか？
+                            </div>
+                             <div class="card-input">
+                                <div class="card-input-count">
+                                    <v-text-field
+                                        v-model="count"
+                                        color="#E0E0E0"
+                                        height="100"
+                                        width="200"
+                                        outlined
+                                        flat
+                                        solo
+                                        :rules="[isInputMinus, isResultMinus]"
+                                    />
+                                </div>
+                                <div class="card-input-unit">{{listItem.unit}}</div>
+                                <div class="add-sub-part">
+                                    <v-btn @click="count++" icon><v-icon>mdi-plus</v-icon></v-btn>
+                                    <v-btn @click="count--" icon><v-icon>mdi-minus</v-icon></v-btn>
+                                </div>
+                             </div>
+                             <div class="card-input-helper">
+                                 <v-btn @click="addUseCount('all')" class="helper-button" color="#616161" text>全部使った</v-btn>
+                                 <v-btn @click="addUseCount('half')" class="helper-button" color="#616161" text>半分使った</v-btn>
+                            </div>
+                        </v-container>
+                    </v-card-text>
+                    <v-divider></v-divider>
+                    <v-card-actions class="card-action">
+                        <v-btn
+                            width="100"
+                            :disabled="canClickOkButton()"
+                            color="teal lighten-3"
+                            class="dialog-action-button"
+                            elevation="0"
+                            @click="closeDialogWithUpdate('use')"
+                        >
+                            OK
+                        </v-btn>
+                        <v-btn
+                            width="100"
+                            color="teal lighten-3"
+                            class="dialog-action-button"
+                            text
+                            @click="closeDialog"
+                        >
+                            キャンセル
+                        </v-btn>
+                    </v-card-actions>
+                </v-card>
+            </v-dialog>
         </div>
     </div>
 </template>
@@ -25,6 +184,16 @@ export default class FoodStaffListItem extends Vue {
 </script>
 
 <style scoped>
+@import url('https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@100;300;400;500;700;800;900&display=swap');
+
+
+.v-text-field >>> input {
+    color: #616161 !important;
+    font-weight: 700;
+    font-size: 40px;
+    text-align: right;
+}
+
 .list_item_root {
     padding: 5px;
     color: #616161;
@@ -49,5 +218,93 @@ export default class FoodStaffListItem extends Vue {
     color: #FFFFFF;
     font-size: 14px;
     font-weight: 700;
+}
+
+.dialog-title {
+    color: #FFFFFF;
+    font-weight: 700 !important;
+    font-family: 'M PLUS Rounded 1c', sans-serif;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.card-container {
+    display: flex;
+    flex-direction: column;
+    padding: 0px !important;
+}
+
+.card-title {
+    color: #616161;
+    font-weight: 700;
+    font-size: 18px;
+    text-align: center;
+    height: 40px;
+    padding: 5px;
+}
+
+.dialog-action-button {
+    color: #FFFFFF;
+    font-weight: 700;
+}
+
+.card-body {
+    height: 240px;
+    padding: 10px !important;
+    font-family: 'M PLUS Rounded 1c', sans-serif;
+}
+
+.card-input {
+    height: 120px;
+    padding: 5px;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+}
+
+.card-input-count {
+    width: 200px;
+}
+
+.add-sub-part {
+    width: 50px;
+    height: 100px;
+    padding: 5px;
+    margin-left: 10px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+}
+.card-input-unit {
+    width: 50px;
+    height: 100px;
+    padding: 10px;
+    margin-left: 10px;
+    color: #616161;
+    font-weight: 700;
+    font-size: 36px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.card-input-helper {
+    height: 70px;
+    padding: 10px;
+    display: flex;
+    justify-content: space-evenly;
+    align-items: center;
+}
+.helper-button {
+    font-weight: 700;
+    font-size: 20px;
+}
+.card-action {
+    height: 70px;
+    display: flex;
+    align-items: center;
+    justify-content: space-evenly;
+    font-family: 'M PLUS Rounded 1c', sans-serif;
 }
 </style>

--- a/client/src/components/foodstaff/FoodStaffRegister.vue
+++ b/client/src/components/foodstaff/FoodStaffRegister.vue
@@ -91,6 +91,7 @@ export default class FoodStaffRegister extends Vue {
 
     post() {
         const requestBody: FoodStaffDetails = {
+            id: 0,
             staffName: this.staffName,
             staffCount: +this.staffCount,
             unit: this.unit,

--- a/client/src/consts.ts
+++ b/client/src/consts.ts
@@ -6,6 +6,7 @@ export type FoodStaffSubCategory = 'vegetables' | 'leftovers'| 'others';
 export type FoodStaffSubCategoryLabel = '野菜' | '残りもの'| 'その他';
 
 export type FoodStaffDetails = {
+    id: number;
     staffName: string;
     staffCount: number;
     unit: FoodCountUnit;

--- a/server/src/foodstaffs/foodstaffs.service.ts
+++ b/server/src/foodstaffs/foodstaffs.service.ts
@@ -20,6 +20,7 @@ export class FoodstaffsService {
 
     async post(data: FoodstaffDto) {
         const staff = this.foodstaffRepository.create(data);
+        staff.inputDate = new Date();
         await this.foodstaffRepository.save(staff);
         return staff;
     }

--- a/server/src/orm.config.ts
+++ b/server/src/orm.config.ts
@@ -9,8 +9,8 @@ export const config: TypeOrmModuleOptions = {
     port: 5432,
     host: 'localhost',
     database: 'kakeibooo',
-    synchronize: true,
+    synchronize: false,
     entities: [Foodstaff],
-    logging: false,//true,
+    logging: true,
     namingStrategy: new SnakeNamingStrategy()
 };


### PR DESCRIPTION
### 特記事項・雑感
- 分数には未対応
- スタイルがぐちゃぐちゃになってきているので何とかしたい

### 画面イメージ
<div>
<img width="300" alt="スクリーンショット 2020-06-07 11 59 06" src="https://user-images.githubusercontent.com/51043054/83959306-5ada6d80-a8b6-11ea-8b15-c79e3166bee3.png">
<img width="300" alt="スクリーンショット 2020-06-07 11 59 17" src="https://user-images.githubusercontent.com/51043054/83959308-5d3cc780-a8b6-11ea-8cdc-e09c4611bb12.png">
</div>
