### PR TITLE
[front] 食材の登録をもっとわかりやすくする

### DIFF
--- a/client/src/components/foodstaff/FoodStaffRegister.vue
+++ b/client/src/components/foodstaff/FoodStaffRegister.vue
@@ -61,7 +61,7 @@ import { defineComponent, reactive, toRefs } from '@vue/composition-api';
 import { FoodCountUnit, FoodStaffCategory, FoodStaffSubCategory, FoodStaffDetails } from '../../consts';
 import { post } from '../../apis/foodStaffApi';
 
-type StaffInfo = {
+type FoodStaffType = {
     staffName: string,
     staffCount: number | string,
     unit: FoodCountUnit,
@@ -72,7 +72,7 @@ type StaffInfo = {
 
 export default defineComponent({
     setup() {
-        const registeredContent = reactive<StaffInfo>({
+        const foodStaffState = reactive<FoodStaffType>({
             staffName: '',
             staffCount: '',
             unit: '個',
@@ -87,14 +87,14 @@ export default defineComponent({
          * 保存先の選択位置を値に変換する
          */
         const convertSelectionToCategory = (): FoodStaffCategory => {
-            return largeClassMap[registeredContent.largeClassSelection];
+            return largeClassMap[foodStaffState.largeClassSelection];
         };
 
         /**
          * 冷蔵庫内の保存先の選択位置を値に変換する
          */
         const convertSelectionToSubCategory = (): FoodStaffSubCategory | null => {
-            return (registeredContent.largeClassSelection !== 1) ? null : smallClassMap[registeredContent.smallClassSelection];
+            return (foodStaffState.largeClassSelection !== 1) ? null : smallClassMap[foodStaffState.smallClassSelection];
         };
 
         /**
@@ -103,9 +103,9 @@ export default defineComponent({
         const postRequest = () => {
             const requestBody: FoodStaffDetails = {
                 id: 0,
-                staffName: registeredContent.staffName,
-                staffCount: +registeredContent.staffCount,
-                unit: registeredContent.unit,
+                staffName: foodStaffState.staffName,
+                staffCount: +foodStaffState.staffCount,
+                unit: foodStaffState.unit,
                 category: convertSelectionToCategory(),
                 subCategory: convertSelectionToSubCategory()
             };
@@ -116,7 +116,7 @@ export default defineComponent({
             });
         };
         return {
-            ...toRefs(registeredContent),
+            ...toRefs(foodStaffState),
             largeClassMap,
             smallClassMap,
             convertSelectionToCategory,

--- a/client/src/components/foodstaff/FoodStaffRegister.vue
+++ b/client/src/components/foodstaff/FoodStaffRegister.vue
@@ -55,20 +55,20 @@
         </div>
 
         <!-- 登録成功時のsnackbar -->
-        <v-snackbar class="snackbar" v-model="isSuccessOpen" timeout="3000" right color="#42A5F5">
+        <v-snackbar class="snackbar" v-model="isSuccessOpen" timeout="2000" right color="#42A5F5">
             <div style="display:flex;align-items:center">
                 <v-icon color="white">mdi-emoticon-happy-outline</v-icon>
                 <div style="font-weight:700;margin-left:5px">{{snackbarMessage}}</div>
             </div>
-            <v-btn icon color="#FFFFFF" @click="isSuccessOpen=false"><v-icon>mdi-window-close</v-icon></v-btn>
+            <v-btn icon color="#FFFFFF" @click="closeSnackbar"><v-icon>mdi-window-close</v-icon></v-btn>
         </v-snackbar>
         <!-- 登録失敗時のsnackbar -->
-        <v-snackbar class="snackbar" v-model="isErrorOpen" timeout="3000" right color="#EF5350">
+        <v-snackbar class="snackbar" v-model="isErrorOpen" timeout="2000" right color="#EF5350">
             <div style="display:flex;align-items:center">
                 <v-icon color="white">mdi-emoticon-cry-outline</v-icon>
                 <div style="font-weight:700;margin-left:5px">{{snackbarMessage}}</div>
             </div>
-            <v-btn icon color="#FFFFFF" @click="isErrorOpen=false"><v-icon>mdi-window-close</v-icon></v-btn>
+            <v-btn icon color="#FFFFFF" @click="closeSnackbar"><v-icon>mdi-window-close</v-icon></v-btn>
         </v-snackbar>
     </v-app>
 </template>
@@ -126,6 +126,12 @@ export default defineComponent({
          */
         const convertSelectionToSubCategory = (): FoodStaffSubCategory | null => {
             return (foodStaffState.largeClassSelection !== 1) ? null : smallClassMap[foodStaffState.smallClassSelection];
+        };
+
+        const closeSnackbar = () => {
+            snackbarState.isSuccessOpen = false;
+            snackbarState.isErrorOpen = false;
+            snackbarState.snackbarMessage = '';
         };
 
         /**

--- a/client/src/components/foodstaff/FoodStaffRegister.vue
+++ b/client/src/components/foodstaff/FoodStaffRegister.vue
@@ -87,6 +87,14 @@ type FoodStaffType = {
     smallClassSelection: number
 };
 
+type SnackbarType = {
+    isSuccessOpen: boolean,
+    isErrorOpen: boolean,
+    snackbarMessage: SnackbarMessageType
+}
+
+type SnackbarMessageType = '' | '入力内容に不備があります' | 'すでに登録されています' | '登録が完了しました';
+
 export default defineComponent({
     setup() {
         const foodStaffState = reactive<FoodStaffType>({
@@ -97,6 +105,12 @@ export default defineComponent({
             largeClassSelection: 0,
             smallClassSelection: 0
         });
+        const snackbarState = reactive<SnackbarType>({
+            isSuccessOpen: false,
+            isErrorOpen: false,
+            snackbarMessage: ''
+        });
+
         const largeClassMap = reactive<FoodStaffCategory[]>(['fridge-top', 'fridge-bottom', 'seasoning', 'preserved']);
         const smallClassMap = reactive<FoodStaffSubCategory[]>(['vegetables', 'leftovers', 'others']);
 
@@ -134,6 +148,7 @@ export default defineComponent({
         };
         return {
             ...toRefs(foodStaffState),
+            ...toRefs(snackbarState),
             largeClassMap,
             smallClassMap,
             convertSelectionToCategory,

--- a/client/src/components/foodstaff/FoodStaffRegister.vue
+++ b/client/src/components/foodstaff/FoodStaffRegister.vue
@@ -132,6 +132,11 @@ export default defineComponent({
          * 入力された食材情報をSVに対して投げる
          */
         const postRequest = () => {
+            if(foodStaffState.staffName === "" || foodStaffState.staffCount === "") {
+                snackbarState.isErrorOpen = true;
+                snackbarState.snackbarMessage = "入力内容に不備があります";
+                return;
+            }
             const requestBody: FoodStaffDetails = {
                 id: 0,
                 staffName: foodStaffState.staffName,

--- a/client/src/components/foodstaff/FoodStaffRegister.vue
+++ b/client/src/components/foodstaff/FoodStaffRegister.vue
@@ -53,6 +53,23 @@
                 </v-btn>
             </div>
         </div>
+
+        <!-- 登録成功時のsnackbar -->
+        <v-snackbar class="snackbar" v-model="isSuccessOpen" timeout="3000" right color="#42A5F5">
+            <div style="display:flex;align-items:center">
+                <v-icon color="white">mdi-emoticon-happy-outline</v-icon>
+                <div style="font-weight:700;margin-left:5px">{{snackbarMessage}}</div>
+            </div>
+            <v-btn icon color="#FFFFFF" @click="isSuccessOpen=false"><v-icon>mdi-window-close</v-icon></v-btn>
+        </v-snackbar>
+        <!-- 登録失敗時のsnackbar -->
+        <v-snackbar class="snackbar" v-model="isErrorOpen" timeout="3000" right color="#EF5350">
+            <div style="display:flex;align-items:center">
+                <v-icon color="white">mdi-emoticon-cry-outline</v-icon>
+                <div style="font-weight:700;margin-left:5px">{{snackbarMessage}}</div>
+            </div>
+            <v-btn icon color="#FFFFFF" @click="isErrorOpen=false"><v-icon>mdi-window-close</v-icon></v-btn>
+        </v-snackbar>
     </v-app>
 </template>
 
@@ -131,6 +148,10 @@ export default defineComponent({
 @import url('https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@100;300;400;500;700;800;900&display=swap');
 
 .food_staff_register {
+    font-family: 'M PLUS Rounded 1c', sans-serif;
+}
+
+.snackbar {
     font-family: 'M PLUS Rounded 1c', sans-serif;
 }
 

--- a/client/src/components/foodstaff/FoodStaffRegister.vue
+++ b/client/src/components/foodstaff/FoodStaffRegister.vue
@@ -76,7 +76,7 @@
 <script lang="ts">
 import { defineComponent, reactive, toRefs } from '@vue/composition-api';
 import { FoodCountUnit, FoodStaffCategory, FoodStaffSubCategory, FoodStaffDetails } from '../../consts';
-import { post } from '../../apis/foodStaffApi';
+import { post, getAll } from '../../apis/foodStaffApi';
 
 type FoodStaffType = {
     staffName: string,
@@ -145,10 +145,20 @@ export default defineComponent({
                 category: convertSelectionToCategory(),
                 subCategory: convertSelectionToSubCategory()
             };
-            post(requestBody).then(response => {
-                // TODO 正常時の分岐もあったほうがよい
-                // TODO エラー処理も後々必要になりそう
-                location.reload();
+            getAll().then(response => {
+                const isDuplicate = (response.data as FoodStaffDetails[]).filter(staff => staff.staffName === foodStaffState.staffName).length > 0;
+                if(isDuplicate) {
+                    snackbarState.isErrorOpen = true;
+                    snackbarState.snackbarMessage = "すでに登録されています";
+                    return;
+                }
+            })
+            .then(() => {
+                post(requestBody).then(response => {
+                    snackbarState.isSuccessOpen = true;
+                    snackbarState.snackbarMessage = "登録が完了しました";
+                    setTimeout(() => location.reload(), 1000);
+                });
             });
         };
         return {


### PR DESCRIPTION
### 特記事項・雑感
* 登録成功時および登録不可（食材名重複、入力不備）時にスナックバーを表示するようにした
* 本来はSVからのレスポンスを待ってから or マウント時にフロント側で食材リストを保持しておき、SVへのGETとは別で食材リストに追加してから スナックバーを出すべきだがうまくできず断念  
→ **別issueで切り出し、Vuexやstoreパターンを使って実現したい**

### 画面イメージ
<div>
<img width="300" alt="スクリーンショット 2020-06-14 18 04 57" src="https://user-images.githubusercontent.com/51043054/84589505-e0878b80-ae69-11ea-825d-b5f6ec5ef8e5.png">
<img width="300" alt="スクリーンショット 2020-06-14 18 01 34" src="https://user-images.githubusercontent.com/51043054/84589502-dbc2d780-ae69-11ea-82da-5e6ff6b622e0.png">
</div>
