### PR TITLE
食費登録画面の実装（クライアントサイド）

### DIFF
--- a/client/kakeibooo.d.ts
+++ b/client/kakeibooo.d.ts
@@ -6,7 +6,7 @@ declare module "*.svg" {
 
 declare module Drawer {
 
-  export type MenuItem = 'home' | 'calendar' | 'analyze' | 'fridge' | 'setting';
+  export type MenuItem = 'home' | 'finance' | 'analyze' | 'fridge' | 'setting';
 
   export interface SvgIconProps {
     color?: string;

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1547,6 +1547,12 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "date-fns": {
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.22.1.tgz",
+      "integrity": "sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg==",
+      "dev": true
+    },
     "debug": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -22,6 +22,7 @@
     "@types/react-dom": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
     "css-loader": "^5.2.4",
+    "date-fns": "^2.22.1",
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.3.1",
     "node-sass": "^5.0.0",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import Drawer from './components/drawer/Drawer';
+import FinanceView from './view/FinanceView';
 
 const App: React.FC = () => {
     return (
@@ -10,11 +11,11 @@ const App: React.FC = () => {
             </div>
             <div className="content">
                 <Switch>
-                    <Route path="home" />
-                    <Route path="calendar" />
-                    <Route path="analyze" />
-                    <Route path="fridge" />
-                    <Route path="setting" />
+                    <Route path="/home" />
+                    <Route path="/finance" component={FinanceView} />
+                    <Route path="/analyze" />
+                    <Route path="/fridge" />
+                    <Route path="/setting" />
                 </Switch>
             </div>
         </Router>

--- a/client/src/components/drawer/Drawer.tsx
+++ b/client/src/components/drawer/Drawer.tsx
@@ -10,7 +10,7 @@ import { EditIcon, FridgeIcon, GraphIcon, HomeIcon, SettingIcon } from './Drawer
 import DrawerAccount from './DrawerAccount';
 
 const Drawer: React.FC = () => {
-    const [value, setValue] = React.useState<Drawer.MenuItem>('calendar');
+    const [value, setValue] = React.useState<Drawer.MenuItem>('home');
 
     const handleChange = (newValue: Drawer.MenuItem) => {
         setValue(newValue);
@@ -21,7 +21,7 @@ const Drawer: React.FC = () => {
             <DrawerAccount />
             <DrawerMenu value={value} onChange={handleChange}>
                 <DrawerMenuButton value="home" className="drawer-menu-item" icon={<HomeIcon />}>ホーム</DrawerMenuButton>
-                <DrawerMenuButton value="calendar" className="drawer-menu-item" icon={<EditIcon />}>家計簿</DrawerMenuButton>
+                <DrawerMenuButton value="finance" className="drawer-menu-item" icon={<EditIcon />}>家計簿</DrawerMenuButton>
                 <DrawerMenuButton value="analyze" className="drawer-menu-item" icon={<GraphIcon />}>分析</DrawerMenuButton>
                 <DrawerMenuButton value="fridge" className="drawer-menu-item" icon={<FridgeIcon />}>冷蔵庫</DrawerMenuButton>
                 <DrawerMenuButton value="setting" className="drawer-menu-item" icon={<SettingIcon />}>設定</DrawerMenuButton>

--- a/client/src/components/drawer/DrawerAccount.tsx
+++ b/client/src/components/drawer/DrawerAccount.tsx
@@ -1,12 +1,12 @@
 import { Avatar } from '@material-ui/core';
 import * as React from 'react';
-import avatarPath from '../../images/avatar.svg';
+import { FaceIcon } from './DrawerSvgIcons';
 
 const DrawerAccount: React.FC = () => {
     return (
         <div className="root--account">
             <div className="image">
-                <Avatar src={avatarPath} className="avatar" variant="circle"  />
+                <FaceIcon />
             </div>
             <div className="username">ぎんぺん</div>
             <div className="userid">@pepepenguin</div>

--- a/client/src/components/drawer/DrawerSvgIcons.tsx
+++ b/client/src/components/drawer/DrawerSvgIcons.tsx
@@ -59,3 +59,22 @@ export const SettingIcon: React.FC<Drawer.SvgIconProps> = (props) => {
 
     )
 }
+
+export const FaceIcon: React.FC<Drawer.SvgIconProps> = (props) => {
+    return (
+        <>
+            <svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg" width="80" height="80">
+                <mask id="mask__beam" maskUnits="userSpaceOnUse" x="0" y="0" width="36" height="36">
+                    <rect width="36" height="36" rx="72" fill="white"></rect>
+                </mask>
+                <g mask="url(#mask__beam)">
+                    <rect width="36" height="36" fill="#424242"></rect>
+                    <rect x="0" y="0" width="36" height="36" transform="translate(7 1) rotate(53 18 18) scale(1.2)" fill="#ff5252" rx="6"></rect>
+                    <g transform="translate(3.5 -2) rotate(3 18 18)">
+                        <path d="M15 21c2 1 4 1 6 0" stroke="black" fill="none" stroke-linecap="round"></path>
+                        <rect x="11" y="14" width="1.5" height="2" rx="1" stroke="none" fill="black"></rect>
+                        <rect x="23" y="14" width="1.5" height="2" rx="1" stroke="none" fill="black"></rect>
+                    </g></g></svg>
+        </>
+    )
+}

--- a/client/src/components/finance/Calendar.tsx
+++ b/client/src/components/finance/Calendar.tsx
@@ -1,0 +1,13 @@
+import CalendarBody from "./CalendarBody"
+import CalendarHeader from "./CalendarHeader"
+
+const Calendar: React.FC = () => {
+    return (
+        <div className="root--calendar">
+            <CalendarHeader />
+            <CalendarBody />
+        </div>
+    )
+}
+
+export default Calendar;

--- a/client/src/components/finance/CalendarBody.tsx
+++ b/client/src/components/finance/CalendarBody.tsx
@@ -1,12 +1,14 @@
 import MonthlyReceiptModel from "./model/MonthlyReceiptModel";
 import CalendarBodyWeek from "./CalendarBodyWeek";
+import { useContext } from "react";
+import { financeContext } from "./FinanceContext";
 
 const CalendarBody: React.FC = () => {
-    const mockModel = new MonthlyReceiptModel();
+    const context = useContext(financeContext);
     return (
         <div className="root--body">
             {
-                Object.values(mockModel.monthlyReceipt).map(week => {
+                Object.values((context.monthlyReceipt).monthlyReceipt).map(week => {
                     return <CalendarBodyWeek value={ week }/>
                 })
             }

--- a/client/src/components/finance/CalendarBody.tsx
+++ b/client/src/components/finance/CalendarBody.tsx
@@ -1,0 +1,17 @@
+import MonthlyReceiptModel from "./model/MonthlyReceiptModel";
+import CalendarBodyWeek from "./CalendarBodyWeek";
+
+const CalendarBody: React.FC = () => {
+    const mockModel = new MonthlyReceiptModel();
+    return (
+        <div className="root--body">
+            {
+                Object.values(mockModel.monthlyReceipt).map(week => {
+                    return <CalendarBodyWeek value={ week }/>
+                })
+            }
+        </div>
+    )
+}
+
+export default CalendarBody;

--- a/client/src/components/finance/CalendarBodyDay.tsx
+++ b/client/src/components/finance/CalendarBodyDay.tsx
@@ -1,0 +1,32 @@
+interface CalendarBodyDayProps {
+    children?: number;
+    value?: number;
+}
+
+const CalendarBodyDay: React.FC<CalendarBodyDayProps> = (props) => {
+    const getClassNameFromCost = (cost: number) => {
+        if (cost > 2500) {
+            return "day high";
+        }
+        if (cost < 1000) {
+            return "day low";
+        }
+        return "day";
+    }
+
+    const className: string = getClassNameFromCost(props.value);
+    return (
+        <div className={className}>
+            <div className="label">
+                {props.children}
+            </div>
+            <div className="value">
+                {
+                    props.value && `¥${props.value.toLocaleString()}`
+                }
+            </div>
+        </div>
+    )
+}
+
+export default CalendarBodyDay;

--- a/client/src/components/finance/CalendarBodyDay.tsx
+++ b/client/src/components/finance/CalendarBodyDay.tsx
@@ -1,32 +1,57 @@
+import { Button } from "@material-ui/core";
+import { useContext } from "react";
+import { financeContext } from "./FinanceContext";
+import * as dfns from 'date-fns';
+
 interface CalendarBodyDayProps {
     children?: number;
     value?: number;
 }
 
 const CalendarBodyDay: React.FC<CalendarBodyDayProps> = (props) => {
+    const context = useContext(financeContext);
+    const today = new Date();
     const getClassNameFromCost = (cost: number) => {
+        let className = 'day';
         if (cost > 2500) {
-            return "day high";
+            className += ' high';
         }
         if (cost < 1000) {
-            return "day low";
+            className += ' low';
         }
-        return "day";
+        if (props.children === dfns.getDate(context.targetDate)) {
+            className += ' selected';
+        }
+        return className;
+    }
+
+    const onClickDay = () => {
+        context.setTargetDate(dfns.setDate(context.targetDate, props.children));
+    }
+
+    const isToday = () => {
+        if (!props.children) {
+            return false;
+        }
+        const displayDate = dfns.set(new Date(), { year: dfns.getYear(context.targetDate), month: dfns.getMonth(context.targetDate), date: props.children });
+        return dfns.isEqual(displayDate, today);
     }
 
     const className: string = getClassNameFromCost(props.value);
     return (
-        <div className={className}>
-            <div className="label">
-                {props.children}
+        <Button className={className} disabled={!props.value} onClick={onClickDay}>
+            <div style={{ height: '100%', width:"100%" }}>
+                <div className="label">
+                    {props.children}
+                    {
+                        isToday() && <div className="label--today">Today</div>
+                    }
+                </div>
+                <div className="value">{props.value && `¥${props.value.toLocaleString()}`}</div>
             </div>
-            <div className="value">
-                {
-                    props.value && `¥${props.value.toLocaleString()}`
-                }
-            </div>
-        </div>
+        </Button>
     )
 }
+
 
 export default CalendarBodyDay;

--- a/client/src/components/finance/CalendarBodyWeek.tsx
+++ b/client/src/components/finance/CalendarBodyWeek.tsx
@@ -1,0 +1,23 @@
+import DailyReceiptModel from "./model/DailyReceiptModel";
+import CalendarBodyDay from './CalendarBodyDay';
+
+interface CalendarBodyWeekProps {
+    value: [DailyReceiptModel, DailyReceiptModel,DailyReceiptModel,DailyReceiptModel,DailyReceiptModel,DailyReceiptModel,DailyReceiptModel]
+}
+
+const CalendarBodyWeek: React.FC<CalendarBodyWeekProps> = (props) => {
+
+    return (
+        <div className="week">
+            {props.value.map(dailyReceipt => {
+                if (dailyReceipt) {
+                    return <CalendarBodyDay value={dailyReceipt.getDailyTotalCost()}>{dailyReceipt.getDate()}</CalendarBodyDay>
+                } else {
+                    return <CalendarBodyDay/>
+                }
+            })}
+        </div>
+    )
+}
+
+export default CalendarBodyWeek;

--- a/client/src/components/finance/CalendarHeader.tsx
+++ b/client/src/components/finance/CalendarHeader.tsx
@@ -1,0 +1,42 @@
+import { Button } from '@material-ui/core';
+import * as dfns from 'date-fns';
+import { getWeekOfMonthWithOptions } from 'date-fns/fp';
+import { useState } from 'react';
+import { LeftArrowIcon, RightArrowIcon } from './FinanceSvgIcons';
+const CalendarHeader: React.FC = () => {
+    const dayOfWeekLabel = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
+    const [displayMonth, setDisplayMonth] = useState<Date>(new Date());
+
+    const getPreviousMonth = () => {
+        setDisplayMonth(dfns.setMonth(displayMonth, displayMonth.getMonth() - 1));
+    }
+
+    const getNextMonth = () => {
+        setDisplayMonth(dfns.setMonth(displayMonth, displayMonth.getMonth() + 1));
+    }
+
+    return (
+        <div className="root--header">
+            <div className="year-and-month">
+                <div>
+                    {displayMonth.toLocaleDateString('en-US', { month: 'long' })} {dfns.getYear(displayMonth)}
+                </div>
+                <div>
+                    <Button onClick={getPreviousMonth}>
+                        <LeftArrowIcon width={32} height={32} color="#546e7a" />
+                    </Button>
+                    <Button onClick={getNextMonth}>
+                        <RightArrowIcon width={32} height={32} color="#546e7a" />
+                    </Button>
+                </div>
+            </div>
+            <div className="day-of-week">
+                {
+                    dayOfWeekLabel.map(str => <div className="element">{str}</div>)
+                }
+            </div>
+        </div>
+    )
+}
+
+export default CalendarHeader;

--- a/client/src/components/finance/CalendarHeader.tsx
+++ b/client/src/components/finance/CalendarHeader.tsx
@@ -1,25 +1,32 @@
 import { Button } from '@material-ui/core';
 import * as dfns from 'date-fns';
-import { getWeekOfMonthWithOptions } from 'date-fns/fp';
-import { useState } from 'react';
+import { useContext } from 'react';
+import { financeContext, useFinance } from './FinanceContext';
 import { LeftArrowIcon, RightArrowIcon } from './FinanceSvgIcons';
+import MonthlyReceiptModel from './model/MonthlyReceiptModel';
 const CalendarHeader: React.FC = () => {
     const dayOfWeekLabel = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
-    const [displayMonth, setDisplayMonth] = useState<Date>(new Date());
+    const context = useContext(financeContext);
 
     const getPreviousMonth = () => {
-        setDisplayMonth(dfns.setMonth(displayMonth, displayMonth.getMonth() - 1));
+        const targetDate = dfns.setMonth(context.targetDate, dfns.getMonth(context.targetDate) - 1);
+        const monthlyReceipt = new MonthlyReceiptModel(dfns.getYear(targetDate), dfns.getMonth(targetDate));
+        context.setMonthlyReceipt(monthlyReceipt);
+        context.setTargetDate(targetDate);
     }
 
     const getNextMonth = () => {
-        setDisplayMonth(dfns.setMonth(displayMonth, displayMonth.getMonth() + 1));
+        const targetDate = dfns.setMonth(context.targetDate, dfns.getMonth(context.targetDate) + 1);
+        const monthlyReceipt = new MonthlyReceiptModel(dfns.getYear(targetDate), dfns.getMonth(targetDate));
+        context.setMonthlyReceipt(monthlyReceipt);
+        context.setTargetDate(targetDate);
     }
 
     return (
         <div className="root--header">
             <div className="year-and-month">
                 <div>
-                    {displayMonth.toLocaleDateString('en-US', { month: 'long' })} {dfns.getYear(displayMonth)}
+                    {(context.targetDate).toLocaleDateString('en-US', { month: 'long' })} {dfns.getYear(context.targetDate)}
                 </div>
                 <div>
                     <Button onClick={getPreviousMonth}>

--- a/client/src/components/finance/FinanceContext.ts
+++ b/client/src/components/finance/FinanceContext.ts
@@ -1,0 +1,37 @@
+import { setMonth } from "date-fns";
+import React from "react";
+import MonthlyReceiptModel from "./model/MonthlyReceiptModel";
+import * as dfns from 'date-fns';
+
+type FinanceContext = {
+    targetDate: Date;
+    monthlyReceipt: MonthlyReceiptModel;
+    setTargetDate: (date: Date) => void;
+    setMonthlyReceipt: (monthlyReceipt: MonthlyReceiptModel) => void;
+}
+
+const defaultFinanceContext: FinanceContext = {
+    targetDate: new Date(),
+    monthlyReceipt: new MonthlyReceiptModel(dfns.getYear(new Date()), dfns.getMonth(new Date())),
+    setTargetDate: () => { },
+    setMonthlyReceipt: () => { }
+};
+
+export const financeContext = React.createContext<FinanceContext>(defaultFinanceContext);
+
+export const useFinance = (): FinanceContext => {
+    const [targetDate, setDate] = React.useState<Date>(new Date());
+    const setTargetDate = React.useCallback((current: Date) => {
+        setDate(current);
+    }, []);
+    const [monthlyReceipt, setReceipt] = React.useState<MonthlyReceiptModel>(new MonthlyReceiptModel(dfns.getYear(new Date()), dfns.getMonth(new Date())));
+    const setMonthlyReceipt = React.useCallback((current: MonthlyReceiptModel) => {
+        setReceipt(current);
+    }, []);
+    return {
+        targetDate,
+        monthlyReceipt,
+        setTargetDate,
+        setMonthlyReceipt
+    }
+}

--- a/client/src/components/finance/FinanceSvgIcons.tsx
+++ b/client/src/components/finance/FinanceSvgIcons.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+
+const getIconHeight = (height?: number) => height|| 24;
+const getIconWidth = (width?: number) => width || 24;
+const getIconColor = (color?: string) => color || "currentColor";
+
+export const CircleIcon: React.FC<Drawer.SvgIconProps> = (props) => {
+    return (
+        <>
+            <svg width={getIconWidth(props.width)} height={getIconHeight(props.height)} viewBox="0 0 24 24" fill="#f5f5f5" xmlns="http://www.w3.org/2000/svg">
+               <path stroke={getIconColor(props.color)} d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+        </>
+    )
+}
+
+export const PinAltIcon: React.FC<Drawer.SvgIconProps> = (props) => {
+    return (
+        <>
+            <svg width={getIconWidth(props.width)} height={getIconHeight(props.height)} viewBox="0 0 24 24" fill="#f5f5f5" xmlns="http://www.w3.org/2000/svg">
+                <path stroke={getIconColor(props.color)} d="M20 10C20 14.4183 12 22 12 22C12 22 4 14.4183 4 10C4 5.58172 7.58172 2 12 2C16.4183 2 20 5.58172 20 10Z" stroke-width="1.5" />
+                <path fill={getIconColor(props.color)} stroke={getIconColor(props.color)} d="M12 11C12.5523 11 13 10.5523 13 10C13 9.44772 12.5523 9 12 9C11.4477 9 11 9.44772 11 10C11 10.5523 11.4477 11 12 11Z" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+        </>
+    )
+}
+
+export const YenScquareIcon: React.FC<Drawer.SvgIconProps> = (props) => {
+    return (
+        <>
+            <svg width={getIconWidth(props.width)} height={getIconHeight(props.height)} viewBox="0 0 24 24" fill="#f5f5f5" xmlns="http://www.w3.org/2000/svg">
+                <path stroke={getIconColor(props.color)} d="M3 20.4V3.6C3 3.26863 3.26863 3 3.6 3H20.4C20.7314 3 21 3.26863 21 3.6V20.4C21 20.7314 20.7314 21 20.4 21H3.6C3.26863 21 3 20.7314 3 20.4Z" stroke-width="1.5"/>
+                <path stroke={getIconColor(props.color)} d="M8 13H16" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                <path stroke={getIconColor(props.color)} d="M8 7L12 12.5M16 7L12 12.5M12 12.5V18" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                <path stroke={getIconColor(props.color)} d="M8 15H16" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+        </>
+    )
+}
+
+export const YenIcon: React.FC<Drawer.SvgIconProps> = (props) => {
+    return (
+        <>
+            <svg width={getIconWidth(props.width)} height={getIconHeight(props.height)} viewBox="0 0 24 24" fill="#f5f5f5" xmlns="http://www.w3.org/2000/svg">
+                <path stroke={getIconColor(props.color)} d="M6 12H18" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                <path stroke={getIconColor(props.color)} d="M6 4L12 12M18 4L12 12M12 12V20" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                <path stroke={getIconColor(props.color)} d="M6 16H18" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </>
+    )
+}
+
+export const TrashIcon: React.FC<Drawer.SvgIconProps> = (props) => {
+    return (
+        <>
+            <svg width={getIconWidth(props.width)} height={getIconHeight(props.height)} viewBox="0 0 24 24" fill="#f5f5f5" xmlns="http://www.w3.org/2000/svg">
+                <path stroke={getIconColor(props.color)} d="M19 11V20.4C19 20.7314 18.7314 21 18.4 21H5.6C5.26863 21 5 20.7314 5 20.4V11" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                <path stroke={getIconColor(props.color)} d="M10 17V11" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                <path stroke={getIconColor(props.color)} d="M14 17V11" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                <path stroke={getIconColor(props.color)} d="M21 7L16 7M3 7L8 7M8 7V3.6C8 3.26863 8.26863 3 8.6 3L15.4 3C15.7314 3 16 3.26863 16 3.6V7M8 7L16 7" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+        </>
+    )
+}

--- a/client/src/components/finance/FinanceSvgIcons.tsx
+++ b/client/src/components/finance/FinanceSvgIcons.tsx
@@ -61,3 +61,32 @@ export const TrashIcon: React.FC<Drawer.SvgIconProps> = (props) => {
         </>
     )
 }
+
+export const LeftArrowIcon: React.FC<Drawer.SvgIconProps> = (props) => {
+    return (
+        <>
+           <svg width={getIconWidth(props.width)} height={getIconHeight(props.height)} stroke-width="1.5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path stroke={getIconColor(props.color)} d="M16.75 12H6.75M6.75 12L9.5 14.75M6.75 12L9.5 9.25" stroke-linecap="round" stroke-linejoin="round"/>
+                <path stroke={getIconColor(props.color)} d="M2 15V9C2 6.79086 3.79086 5 6 5H18C20.2091 5 22 6.79086 22 9V15C22 17.2091 20.2091 19 18 19H6C3.79086 19 2 17.2091 2 15Z" stroke-width="1.5" />
+            </svg>
+        </>
+    )
+}
+
+export const RightArrowIcon: React.FC<Drawer.SvgIconProps> = (props) => {
+    return (
+        <>
+            <svg width={getIconWidth(props.width)} height={getIconHeight(props.height)} stroke-width="1.5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path stroke={getIconColor(props.color)} d="M6.75 12H16.75M16.75 12L14 14.75M16.75 12L14 9.25" stroke-linecap="round" stroke-linejoin="round"/>
+                <path stroke={getIconColor(props.color)} d="M2 15V9C2 6.79086 3.79086 5 6 5H18C20.2091 5 22 6.79086 22 9V15C22 17.2091 20.2091 19 18 19H6C3.79086 19 2 17.2091 2 15Z" stroke-width="1.5"/>
+            </svg>
+        </>
+    )
+}
+
+
+
+
+
+
+

--- a/client/src/components/finance/Receipt.tsx
+++ b/client/src/components/finance/Receipt.tsx
@@ -7,7 +7,6 @@ import ReceiptHeader from './ReceiptHeader';
 
 const Receipt: React.FC = () => {
     const context = useReceipt();
-    console.log(context);
     return (
         <div className="root--receipt">
             <receiptContext.Provider value={context}>

--- a/client/src/components/finance/Receipt.tsx
+++ b/client/src/components/finance/Receipt.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { useReceipt, receiptContext } from './ReceiptContext';
+import ReceiptBody from './ReceiptBody';
+import ReceiptFooter from './ReceiptFooter';
+import ReceiptHeader from './ReceiptHeader';
+
+
+const Receipt: React.FC = () => {
+    const context = useReceipt();
+    console.log(context);
+    return (
+        <div className="root--receipt">
+            <receiptContext.Provider value={context}>
+                <ReceiptHeader />
+                <ReceiptBody />
+                <ReceiptFooter />
+            </receiptContext.Provider>
+        </div>
+    )
+}
+
+export default Receipt;

--- a/client/src/components/finance/ReceiptBody.tsx
+++ b/client/src/components/finance/ReceiptBody.tsx
@@ -11,7 +11,7 @@ const ReceiptBody: React.FC = () => {
 
     const addReceiptTag = () => {
         const current = context.dailyReceipt;
-        current.add(new ReceiptModel("", 0));
+        current.add(new ReceiptModel(new Date(), "", 0));
         context.setDailyReceipt(new DailyReceiptModel(current.receipts));
     }
 

--- a/client/src/components/finance/ReceiptBody.tsx
+++ b/client/src/components/finance/ReceiptBody.tsx
@@ -1,0 +1,34 @@
+import { Button } from '@material-ui/core';
+import { useContext } from 'react';
+import DailyReceiptModel from './model/DailyReceiptModel';
+import ReceiptModel from './model/ReceiptModel';
+import { receiptContext } from './ReceiptContext';
+import ReceiptTag from './ReceiptTag';
+
+const ReceiptBody: React.FC = () => {
+    const context = useContext(receiptContext);
+    const isAddButtonDisabled = context.dailyReceipt.isReachDailyMax();
+
+    const addReceiptTag = () => {
+        const current = context.dailyReceipt;
+        current.add(new ReceiptModel("", 0));
+        context.setDailyReceipt(new DailyReceiptModel(current.receipts));
+    }
+
+    return (
+        <div className="root--body">
+            <div className="sample">
+                {
+                    (context.dailyReceipt.receipts).map((receipt, ordinary) => <ReceiptTag model={receipt} ordinary={ordinary}></ReceiptTag>)
+                }
+                <Button className={isAddButtonDisabled ? "btn--add-receipt disabled" : "btn--add-receipt"} fullWidth variant="outlined" onClick={addReceiptTag} disabled={isAddButtonDisabled}>+ レシートを追加</Button>
+            </div>
+            <div　className="sum">
+                <div>合計</div>
+                <div>￥{context.dailyReceipt.getDailyTotalCost().toLocaleString()}</div>
+            </div>
+        </div>
+    )
+}
+
+export default ReceiptBody;

--- a/client/src/components/finance/ReceiptContext.ts
+++ b/client/src/components/finance/ReceiptContext.ts
@@ -1,0 +1,22 @@
+import { createContext, useCallback, useState } from "react";
+import DailyReceiptModel from "./model/DailyReceiptModel";
+
+interface ReceiptContext {
+    dailyReceipt: DailyReceiptModel;
+    setDailyReceipt: (dailyReceipt: DailyReceiptModel) => void;
+}
+
+const defaultReceiptContext: ReceiptContext = {
+    dailyReceipt: new DailyReceiptModel([]),
+    setDailyReceipt: () => { }
+}
+
+export const receiptContext = createContext<ReceiptContext>(defaultReceiptContext);
+export const useReceipt = (): ReceiptContext => {
+    const [dailyReceipt, _setDailyReceipt] = useState<DailyReceiptModel>(new DailyReceiptModel([]));
+    const setDailyReceipt = useCallback((current: DailyReceiptModel) => _setDailyReceipt(current), []);
+    return {
+        dailyReceipt,
+        setDailyReceipt,
+    }
+}

--- a/client/src/components/finance/ReceiptFooter.tsx
+++ b/client/src/components/finance/ReceiptFooter.tsx
@@ -1,0 +1,21 @@
+import { Button } from '@material-ui/core';
+import { useContext } from 'react';
+import { receiptContext } from './ReceiptContext';
+
+const ReceiptFooter: React.FC = () => {
+    const context = useContext(receiptContext);
+    const isRegisterButtonDisabled = context.dailyReceipt.getCount() === 0;
+    const isNMDayButtonDisabled = context.dailyReceipt.getCount() > 0;
+
+    const registerDailyReceipt = () => {
+        console.log(context.dailyReceipt);
+    }
+    return (
+        <div className="root--footer">
+            <Button className={isRegisterButtonDisabled ? "button--register disabled" : "button--register"} disabled={isRegisterButtonDisabled} fullWidth onClick={registerDailyReceipt}>食費を確定</Button>
+            <Button className={isNMDayButtonDisabled ? "button--nomoney disabled" : "button--nomoney"} disabled={isNMDayButtonDisabled} fullWidth>NOマネーデイとして登録</Button>
+        </div>
+    )
+}
+
+export default ReceiptFooter;

--- a/client/src/components/finance/ReceiptHeader.tsx
+++ b/client/src/components/finance/ReceiptHeader.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import logo from '../../images/icon.svg';
+
+const ReceiptHeader: React.FC = () => {
+    return (
+        <div className="root--header">
+            <div className="title">Kakeibooo</div>
+            <div className="date">2021/05/23（日）</div>
+        </div>
+    )
+}
+
+export default ReceiptHeader;

--- a/client/src/components/finance/ReceiptHeader.tsx
+++ b/client/src/components/finance/ReceiptHeader.tsx
@@ -1,11 +1,26 @@
 import * as React from 'react';
-import logo from '../../images/icon.svg';
+import { financeContext, useFinance } from './FinanceContext';
+import * as dfns from 'date-fns';
 
 const ReceiptHeader: React.FC = () => {
+    const dayOfWeekLabel = ['日', '月', '火', '水', '木', '金', '土'];
+    const getDisplayYMDD = (targetDate: Date) => {
+        const zeroPadding = (val: number) => ('000' + val).slice(-2);
+        return [
+            dfns.getYear(targetDate),
+            zeroPadding(dfns.getMonth(targetDate) + 1),
+            zeroPadding(dfns.getDate(targetDate)),
+            dayOfWeekLabel[dfns.getDay(targetDate)]
+        ]
+    }
+    const context = React.useContext(financeContext);
+    const [dispYear, dispMonth, dispDate, dispDay] = getDisplayYMDD(context.targetDate);
+
     return (
         <div className="root--header">
             <div className="title">Kakeibooo</div>
-            <div className="date">2021/05/23（日）</div>
+            <div className="date">
+                {dispYear}/{dispMonth}/{dispDate}（{dispDay}）</div>
         </div>
     )
 }

--- a/client/src/components/finance/ReceiptTag.tsx
+++ b/client/src/components/finance/ReceiptTag.tsx
@@ -1,0 +1,60 @@
+import { IconButton, InputBase } from "@material-ui/core";
+import { ChangeEvent, useContext } from "react";
+import { CircleIcon, PinAltIcon, TrashIcon, YenIcon } from "./FinanceSvgIcons";
+import DailyReceiptModel from "./model/DailyReceiptModel";
+import ReceiptModel from "./model/ReceiptModel";
+import { receiptContext } from "./ReceiptContext";
+
+interface ReceiptTagProps {
+    model: ReceiptModel;
+    ordinary: number;
+}
+
+const ReceiptTag: React.FC<ReceiptTagProps> = (props) => {
+    const context = useContext(receiptContext);
+
+    const getCurrentDailyReceipt = () => context.dailyReceipt;
+    const setNewDailyReceipt = (newDailyReceipt: ReceiptModel[]) => context.setDailyReceipt(new DailyReceiptModel(newDailyReceipt));
+
+    const onDetectInputChange = (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>, target: 'storeName' | 'cost') => {
+        const current = getCurrentDailyReceipt();
+        const inputText = (event.target as HTMLInputElement).value;
+        if (target === "storeName") {
+            current.receipts[props.ordinary].storeName = inputText;
+        } else {
+            current.receipts[props.ordinary].cost = +inputText;
+        }
+        setNewDailyReceipt(current.receipts);
+    }
+
+    const onDeleteClick = () => {
+        const current = getCurrentDailyReceipt();
+        current.delete(props.ordinary);
+        setNewDailyReceipt(current.receipts);
+    }
+
+    return (
+        <div className="tag">
+            <div className="left">
+                <CircleIcon color="#f5f5f5" width={10} />
+            </div>
+            <div className="center">
+                <div className="part--input">
+                    <PinAltIcon width={28} color="#546e7a"/>
+                    <InputBase margin="dense" value={props.model.storeName} onChange={(event) => onDetectInputChange(event, 'storeName')}/>
+                </div>
+                <div className="part--input">
+                    <YenIcon width={28} color="#546e7a" />
+                    <InputBase margin="dense" className="yen" value={props.model.cost === 0 ? null : props.model.cost} onChange={(event) => onDetectInputChange(event, 'cost')} />
+                </div>
+            </div>
+            <div className="right">
+                <IconButton className="btn--trash" onClick={onDeleteClick}>
+                    <TrashIcon color="#546e7a" />
+                </IconButton>
+            </div>
+        </div>
+    )
+}
+
+export default ReceiptTag;

--- a/client/src/components/finance/model/DailyReceiptModel.ts
+++ b/client/src/components/finance/model/DailyReceiptModel.ts
@@ -1,0 +1,41 @@
+import ReceiptModel from "./ReceiptModel";
+
+export default class DailyReceiptModel {
+    private static DAILY_MAX_RECEIPT = 4;
+
+    private _receipts: ReceiptModel[] = [];
+
+    constructor(receipts: ReceiptModel[]) {
+        this._receipts = receipts;
+    }
+
+    get receipts() {
+        return this._receipts;
+    }
+
+    set receipts(receipts: ReceiptModel[]) {
+        this._receipts = receipts;
+    }
+
+    public add = (receipt: ReceiptModel) => {
+        this._receipts = [...this._receipts, receipt];
+    }
+
+    public delete = (index: number) => {
+        this._receipts = this._receipts.filter((_, i) => i !== index);
+    }
+
+    public isReachDailyMax = () => {
+        return this._receipts.length === DailyReceiptModel.DAILY_MAX_RECEIPT;
+    }
+
+    public getCount = () => {
+        return this._receipts.length;
+    }
+
+    public getDailyTotalCost = (): number => {
+        return this._receipts.reduce((accumulator: number, receipt: ReceiptModel): number => {
+            return accumulator + receipt.cost;
+        }, 0);
+    }
+}

--- a/client/src/components/finance/model/DailyReceiptModel.ts
+++ b/client/src/components/finance/model/DailyReceiptModel.ts
@@ -38,4 +38,8 @@ export default class DailyReceiptModel {
             return accumulator + receipt.cost;
         }, 0);
     }
+
+    public getDate = () => {
+        return this._receipts[0].date.getDate();
+    }
 }

--- a/client/src/components/finance/model/MonthlyReceiptModel.ts
+++ b/client/src/components/finance/model/MonthlyReceiptModel.ts
@@ -1,0 +1,51 @@
+import DailyReceiptModel from "./DailyReceiptModel";
+import ReceiptModel from "./ReceiptModel";
+import { getDay, getWeekOfMonth, endOfMonth } from 'date-fns';
+
+type WeekIndex = 1 | 2 | 3 | 4 | 5 | 6;
+type MonthlyReceipt = {
+    [key in WeekIndex]: [DailyReceiptModel | null, DailyReceiptModel | null, DailyReceiptModel | null, DailyReceiptModel | null, DailyReceiptModel | null, DailyReceiptModel | null, DailyReceiptModel | null];
+}
+
+export default class MonthlyReceiptModel {
+    private _monthlyReceipt: MonthlyReceipt;
+
+    constructor() {
+        this.initialize();
+        this.setWeeklyReceipt();
+    }
+
+    get monthlyReceipt() {
+        return this._monthlyReceipt;
+    }
+
+    set monthlyReceipt(monthlyReceipt: MonthlyReceipt) {
+        this._monthlyReceipt = monthlyReceipt;
+    }
+
+    private initialize() {
+        this._monthlyReceipt = {
+            1: [null, null, null, null, null, null, null],
+            2: [null, null, null, null, null, null, null],
+            3: [null, null, null, null, null, null, null],
+            4: [null, null, null, null, null, null, null],
+            5: [null, null, null, null, null, null, null],
+            6: [null, null, null, null, null, null, null]
+        }
+    }
+
+    private setWeeklyReceipt() {
+        const targetMonth = 7;
+        const endDate = endOfMonth(new Date(2021, targetMonth - 1, 1)).getDate();
+        for (let i = 1; i <= endDate; i++) {
+            const targetDate = new Date(2021, targetMonth - 1, i);
+            // TODO とりあえずのモック
+            this._monthlyReceipt[getWeekOfMonth(targetDate) as WeekIndex][getDay(targetDate)]
+                = new DailyReceiptModel([
+                    new ReceiptModel(targetDate, "", (Math.floor(Math.random() * 1000) + Math.floor((Math.random() * 100) + 100))),
+                    new ReceiptModel(targetDate, "", (Math.floor(Math.random() * 1000) + Math.floor((Math.random() * 100) + 100))),
+                    new ReceiptModel(targetDate, "", (Math.floor(Math.random() * 1000) + Math.floor((Math.random() * 100) + 100)))
+                ]);
+        }
+    }
+}

--- a/client/src/components/finance/model/MonthlyReceiptModel.ts
+++ b/client/src/components/finance/model/MonthlyReceiptModel.ts
@@ -10,9 +10,9 @@ type MonthlyReceipt = {
 export default class MonthlyReceiptModel {
     private _monthlyReceipt: MonthlyReceipt;
 
-    constructor() {
+    constructor(year: number, month: number) {
         this.initialize();
-        this.setWeeklyReceipt();
+        this.setWeeklyReceipt(year, month);
     }
 
     get monthlyReceipt() {
@@ -34,11 +34,10 @@ export default class MonthlyReceiptModel {
         }
     }
 
-    private setWeeklyReceipt() {
-        const targetMonth = 7;
-        const endDate = endOfMonth(new Date(2021, targetMonth - 1, 1)).getDate();
+    private setWeeklyReceipt(year: number, month: number) {
+        const endDate = endOfMonth(new Date(year, month, 1)).getDate();
         for (let i = 1; i <= endDate; i++) {
-            const targetDate = new Date(2021, targetMonth - 1, i);
+            const targetDate = new Date(year, month, i);
             // TODO とりあえずのモック
             this._monthlyReceipt[getWeekOfMonth(targetDate) as WeekIndex][getDay(targetDate)]
                 = new DailyReceiptModel([

--- a/client/src/components/finance/model/ReceiptModel.ts
+++ b/client/src/components/finance/model/ReceiptModel.ts
@@ -1,0 +1,26 @@
+export default class ReceiptModel {
+    private _storeName: string;
+    private _cost: number;
+    private _ordinary: number;
+
+    constructor(storeName: string, cost: number) {
+        this._storeName = storeName;
+        this._cost = cost;
+    }
+
+    get storeName() {
+        return this._storeName;
+    }
+
+    set storeName(storeName: string) {
+        this._storeName = storeName;
+    }
+
+    get cost() {
+        return this._cost;
+    }
+
+    set cost(cost: number) {
+        this._cost = cost;
+    }
+}

--- a/client/src/components/finance/model/ReceiptModel.ts
+++ b/client/src/components/finance/model/ReceiptModel.ts
@@ -1,11 +1,20 @@
 export default class ReceiptModel {
+    private _date: Date;
     private _storeName: string;
     private _cost: number;
-    private _ordinary: number;
 
-    constructor(storeName: string, cost: number) {
+    constructor(date: Date, storeName: string, cost: number) {
+        this._date = date;
         this._storeName = storeName;
         this._cost = cost;
+    }
+
+    get date() {
+        return this._date;
+    }
+
+    set date(date: Date) {
+        this._date = date;
     }
 
     get storeName() {

--- a/client/src/style/finance.scss
+++ b/client/src/style/finance.scss
@@ -1,4 +1,5 @@
 @import url("https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@100;300;400;500;700;800;900&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Fredoka+One&display=swap");
 
 #root--finance {
   height: calc(100vh - 24px);
@@ -49,33 +50,45 @@
         .day {
           background: #fafafa;
           color: #546e7a;
-          margin: 4px;
+          margin: 2px;
           width: calc(100% / 7);
-          border: 1px solid none;
+          border: 2px solid #eceff1;
           border-radius: 8px;
           padding: 4px;
           font-weight: 700;
           .label {
-            padding: 0 4px;
-            height: 30%;
+            padding: 0 8px;
+            height: 20%;
             display: flex;
             justify-content: space-between;
             align-items: flex-start;
+            .label--today {
+              font-family: "Fredoka One", cursive;
+              color: #ffb74d;
+            }
           }
           .value {
-            height: 70%;
+            height: 80%;
             display: flex;
             align-items: center;
             justify-content: center;
             font-size: 20px;
             font-weight: 900;
           }
+          .MuiButton-label {
+            height: 100%;
+            display: flex;
+          }
+          font-family: "M PLUS Rounded 1c", sans-serif;
         }
         .high {
           background: #ffcdd2;
         }
         .low {
           background: #b2dfdb;
+        }
+        .selected {
+          border: 2px dashed #546e7a;
         }
       }
     }

--- a/client/src/style/finance.scss
+++ b/client/src/style/finance.scss
@@ -1,0 +1,149 @@
+@import url("https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@100;300;400;500;700;800;900&display=swap");
+
+#root--finance {
+  height: calc(100vh - 24px);
+  padding: 12px;
+
+  .root--receipt {
+    width: 25%;
+    height: calc(100vh - 24px);
+    background: #ffffff;
+    border: 2px solid #ffffff;
+    border-radius: 4px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+
+    .root--header {
+      height: 10%;
+      padding: 8px;
+      text-align: center;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      border-bottom: 2px dashed #cfd8dc;
+      .title {
+        color: #546e7a;
+        font-weight: 900;
+        font-size: 24px;
+      }
+      .date {
+        color: #4db6ac;
+        font-weight: 900;
+        font-size: 18px;
+      }
+    }
+    .root--body {
+      height: 70%;
+      padding: 8px;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      align-items: center;
+      .sample {
+        height: 100%;
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
+      .sum {
+        width: calc(100% - 16px);
+        font-size: 24px;
+        font-weight: 900;
+        color: #546e7a;
+        display: flex;
+        justify-content: space-between;
+      }
+      .tag {
+        height: 18%;
+        margin-bottom: 8px;
+        background: #f5f5f5;
+        display: flex;
+        .left {
+          background: #4db6ac;
+          width: 10%;
+          height: 100%;
+          display: flex;
+          justify-content: center;
+          align-items: center;
+        }
+        .center {
+          width: 80%;
+          padding: 4px 4px 4px 12px;
+          display: flex;
+          justify-content: space-around;
+          flex-direction: column;
+          .part--input {
+            display: flex;
+            align-items: center;
+            input {
+              font-family: "M PLUS Rounded 1c", sans-serif;
+              padding: 0 0 0 4px;
+              color: #546e7a;
+              font-weight: 800;
+              font-size: 16px;
+              border-bottom: 1px solid #e0e0e0;
+              width: 90%;
+            }
+          }
+        }
+        .right {
+          display: flex;
+          align-items: center;
+          padding: 0 4px 0 0;
+          .btn--trash {
+            height: 50%;
+          }
+        }
+      }
+      .btn--add-receipt {
+        width: 80%;
+        border-color: #546e7a;
+        color: #546e7a;
+        border-radius: 100px;
+        font-size: 12px;
+        font-weight: 600;
+        font-family: "M PLUS Rounded 1c", sans-serif;
+      }
+      .disabled {
+        background: #f5f5f5;
+        border-color: #bdbdbd;
+        color: #bdbdbd;
+      }
+    }
+    .root--footer {
+      height: 20%;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: space-evenly;
+      border-top: 2px dashed #cfd8dc;
+      .button--nomoney {
+        width: 80%;
+        background: #ffb74d;
+        color: #ffffff;
+        border: 1px solid #ffb74d;
+        border-radius: 100px;
+        font-size: 14px;
+        font-weight: 600;
+        font-family: "M PLUS Rounded 1c", sans-serif;
+      }
+      .button--register {
+        width: 80%;
+        background: #546e7a;
+        color: #ffffff;
+        border: 1px solid #546e7a;
+        border-radius: 100px;
+        font-size: 14px;
+        font-weight: 600;
+        font-family: "M PLUS Rounded 1c", sans-serif;
+      }
+      .disabled {
+        background: #f5f5f5;
+        border-color: #bdbdbd;
+        color: #bdbdbd;
+      }
+    }
+  }
+}

--- a/client/src/style/finance.scss
+++ b/client/src/style/finance.scss
@@ -3,7 +3,83 @@
 #root--finance {
   height: calc(100vh - 24px);
   padding: 12px;
+  display: flex;
+  justify-content: space-between;
 
+  .root--calendar {
+    width: 75%;
+    height: calc(100vh - 48px);
+    padding: 12px;
+
+    .root--header {
+      height: 10%;
+      display: flex;
+      flex-direction: column;
+      .year-and-month {
+        height: 50%;
+        font-size: 24px;
+        color: #546e7a;
+        font-weight: 900;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+      .day-of-week {
+        display: flex;
+        height: 50%;
+        align-items: flex-end;
+        .element {
+          padding-bottom: 2px;
+          font-size: 14px;
+          font-weight: 600;
+          width: calc(100% / 7);
+          color: #546e7a;
+          border-bottom: 1.5px solid #546e7a;
+        }
+      }
+    }
+
+    .root--body {
+      height: 90%;
+      padding-top: 12px;
+      .week {
+        height: calc(100% / 6);
+        display: flex;
+
+        .day {
+          background: #fafafa;
+          color: #546e7a;
+          margin: 4px;
+          width: calc(100% / 7);
+          border: 1px solid none;
+          border-radius: 8px;
+          padding: 4px;
+          font-weight: 700;
+          .label {
+            padding: 0 4px;
+            height: 30%;
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+          }
+          .value {
+            height: 70%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 20px;
+            font-weight: 900;
+          }
+        }
+        .high {
+          background: #ffcdd2;
+        }
+        .low {
+          background: #b2dfdb;
+        }
+      }
+    }
+  }
   .root--receipt {
     width: 25%;
     height: calc(100vh - 24px);

--- a/client/src/view/FinanceView.tsx
+++ b/client/src/view/FinanceView.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
+import Calendar from '../components/finance/Calendar';
 import Receipt from '../components/finance/Receipt';
 import '../style/finance.scss';
 
 const CalendarView: React.FC = () => {
     return (
         <div id="root--finance">
+            <Calendar />
             <Receipt />
         </div>
     )

--- a/client/src/view/FinanceView.tsx
+++ b/client/src/view/FinanceView.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import Receipt from '../components/finance/Receipt';
+import '../style/finance.scss';
+
+const CalendarView: React.FC = () => {
+    return (
+        <div id="root--finance">
+            <Receipt />
+        </div>
+    )
+}
+
+export default CalendarView;

--- a/client/src/view/FinanceView.tsx
+++ b/client/src/view/FinanceView.tsx
@@ -2,12 +2,16 @@ import * as React from 'react';
 import Calendar from '../components/finance/Calendar';
 import Receipt from '../components/finance/Receipt';
 import '../style/finance.scss';
+import { financeContext, useFinance } from '../components/finance/FinanceContext';
 
 const CalendarView: React.FC = () => {
+    const context = useFinance();
     return (
         <div id="root--finance">
-            <Calendar />
-            <Receipt />
+            <financeContext.Provider value={context}>
+                <Calendar />
+                <Receipt />
+            </financeContext.Provider>
         </div>
     )
 }


### PR DESCRIPTION
クライアント側で完結した食費登録画面を実装

* 食費が入力できる（最大4店舗/日）
* カレンダーで月日が選択できる
* 食費に応じてカレンダーの色が変わる、今日および選択中の日付だけデザインを変える

<img width="1439" alt="スクリーンショット 2021-07-24 11 54 12" src="https://user-images.githubusercontent.com/51043054/126855489-dacdae8f-6a29-442d-8bfa-7fb07b4ce86c.png">
