### PR TITLE
[KKB-41] Snackbarコンポーネントを食費カレンダーから分離する

### DIFF
--- a/src/components/common/snackbar/Snackbar.tsx
+++ b/src/components/common/snackbar/Snackbar.tsx
@@ -58,16 +58,16 @@ const snackbarBase = (color: string, theme: Theme) => css`
   gap: ${theme.units.px8};
   position: absolute;
   box-shadow: 3px 3px 3px #9e9e9e;
-  top: ${theme.units.px8};
+  bottom: ${theme.units.px8};
   right: ${theme.units.px16};
   animation: fadein 1s forwards;
   @keyframes fadein {
     0% {
-      transform: translateX(300px);
+      transform: translateY(300px);
     }
 
     100% {
-      transform: translateX(0px);
+      transform: translateY(0px);
     }
   }
 `;

--- a/src/components/common/snackbar/useSnackbar.spec.ts
+++ b/src/components/common/snackbar/useSnackbar.spec.ts
@@ -6,7 +6,7 @@ describe('useSnackbar', () => {
   test('Snackbarは3秒間だけ表示される', async () => {
     const { result, waitFor } = renderHook(() => useSnackbar());
     act(() => {
-      result.current.setIsOpen(true);
+      result.current.showSnackbar();
     });
     expect(result.current.isOpen).toBeTruthy();
     await waitFor(

--- a/src/components/common/snackbar/useSnackbar.spec.ts
+++ b/src/components/common/snackbar/useSnackbar.spec.ts
@@ -1,0 +1,30 @@
+/** @jest-environment jsdom */
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useSnackbar } from './useSnackbar';
+
+describe('useSnackbar', () => {
+  test('Snackbarは3秒間だけ表示される', async () => {
+    const { result, waitFor } = renderHook(() => useSnackbar());
+    act(() => {
+      result.current.setIsOpen(true);
+    });
+    expect(result.current.isOpen).toBeTruthy();
+    await waitFor(
+      () => {
+        expect(result.current.isOpen).toBeFalsy();
+      },
+      {
+        timeout: 3500,
+      }
+    );
+  });
+  test('値を正しく設定できる', () => {
+    const { result } = renderHook(() => useSnackbar());
+    act(() => {
+      result.current.setSnackbarDetails('success', 'タイトル', 'サブタイトル');
+    });
+    expect(result.current.type).toBe('success');
+    expect(result.current.text).toBe('タイトル');
+    expect(result.current.subText).toBe('サブタイトル');
+  });
+});

--- a/src/components/common/snackbar/useSnackbar.ts
+++ b/src/components/common/snackbar/useSnackbar.ts
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 export const useSnackbar = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -12,6 +12,10 @@ export const useSnackbar = () => {
     setTimeout(() => setIsOpen(false), 3000);
   }, [isOpen]);
 
+  const showSnackbar = useCallback(() => {
+    setIsOpen(true);
+  }, [setIsOpen]);
+
   const setSnackbarDetails = useCallback((newType: 'success' | 'error', newText: string, newSubText: string) => {
     setType(newType);
     setText(newText);
@@ -22,7 +26,7 @@ export const useSnackbar = () => {
     type,
     text,
     subText,
-    setIsOpen,
+    showSnackbar,
     setSnackbarDetails,
   };
 };
@@ -33,6 +37,6 @@ export type UseSnackbarReturnType = {
   type: 'success' | 'error';
   text: string;
   subText: string;
-  setIsOpen: Dispatch<SetStateAction<boolean>>;
+  showSnackbar: () => void;
   setSnackbarDetails: (newType: string, newText: string, newSubText: string) => void;
 };

--- a/src/components/common/snackbar/useSnackbar.ts
+++ b/src/components/common/snackbar/useSnackbar.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { Dispatch, SetStateAction, useCallback, useEffect, useState } from 'react';
 
 export const useSnackbar = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -25,4 +25,14 @@ export const useSnackbar = () => {
     setIsOpen,
     setSnackbarDetails,
   };
+};
+
+// TODO もっと賢いやり方
+export type UseSnackbarReturnType = {
+  isOpen: boolean;
+  type: 'success' | 'error';
+  text: string;
+  subText: string;
+  setIsOpen: Dispatch<SetStateAction<boolean>>;
+  setSnackbarDetails: (newType: string, newText: string, newSubText: string) => void;
 };

--- a/src/components/common/snackbar/useSnackbar.ts
+++ b/src/components/common/snackbar/useSnackbar.ts
@@ -1,0 +1,28 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export const useSnackbar = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [type, setType] = useState<'success' | 'error'>('success');
+  const [text, setText] = useState('');
+  const [subText, setSubText] = useState('');
+
+  useEffect(() => {
+    if (!isOpen) return;
+    // 表示してから3秒経ったら勝手に消す;
+    setTimeout(() => setIsOpen(false), 3000);
+  }, [isOpen]);
+
+  const setSnackbarDetails = useCallback((newType: 'success' | 'error', newText: string, newSubText: string) => {
+    setType(newType);
+    setText(newText);
+    setSubText(newSubText);
+  }, []);
+  return {
+    isOpen,
+    type,
+    text,
+    subText,
+    setIsOpen,
+    setSnackbarDetails,
+  };
+};

--- a/src/components/receipt/Receipt.test.tsx
+++ b/src/components/receipt/Receipt.test.tsx
@@ -4,8 +4,10 @@ import { composeStories } from '@storybook/testing-react';
 import { useReceipt, UseReceiptReturnType } from './useReceipt';
 import { render } from '../../test-utils';
 import * as ReceiptStories from './Receipt.stories';
+import { useSnackbar, UseSnackbarReturnType } from '../common/snackbar/useSnackbar';
 
 jest.mock('./useReceipt');
+jest.mock('../common/snackbar/useSnackbar');
 
 describe('Receiptコンポーネント', () => {
   const {
@@ -18,31 +20,40 @@ describe('Receiptコンポーネント', () => {
     ClickNoMoneyDisabled,
   } = composeStories(ReceiptStories);
   // TODO もっとよいやり方がある...？
-  const mockResponse: UseReceiptReturnType = {
+  const mockUseReceipt: UseReceiptReturnType = {
     dailyReceipt: [],
-    snackbarStatus: { open: false, text: '', type: 'error' },
     calcSummartion: jest.fn(),
     onReceiptAdd: jest.fn(),
     onChangeStoreName: jest.fn(),
     onChangeCost: jest.fn(),
     onReceiptDelete: jest.fn(),
-    showSnackbar: jest.fn(),
     cannotAddReceipt: false,
     cannotRegistReceipt: false,
     cannotRegistNoMoney: false,
     validate: jest.fn(),
   };
+  const mockUseSnackbar: UseSnackbarReturnType = {
+    isOpen: false,
+    type: 'success',
+    text: '',
+    subText: '',
+    setIsOpen: jest.fn(),
+    setSnackbarDetails: jest.fn(),
+  };
   const useReceiptSpy = jest.spyOn({ useReceipt }, 'useReceipt');
+  const useSnackbarSpy = jest.spyOn({ useSnackbar }, 'useSnackbar');
   it('レシートが3枚以下の場合、「レシートを追加」をクリックするとメソッドが呼ばれる', async () => {
     const clickListener = jest.fn();
-    useReceiptSpy.mockReturnValue({ ...mockResponse, onReceiptAdd: clickListener });
+    useReceiptSpy.mockReturnValue({ ...mockUseReceipt, onReceiptAdd: clickListener });
+    useSnackbarSpy.mockReturnValue(mockUseSnackbar);
     const { container } = render(<ClickAddReceipt />);
     await ClickAddReceipt.play({ canvasElement: container });
     expect(clickListener).toHaveBeenCalled();
   });
   it('レシートが4枚の場合、「レシートを追加」をクリックしてもメソッドは呼ばれない', async () => {
     const clickListener = jest.fn();
-    useReceiptSpy.mockReturnValue({ ...mockResponse, cannotAddReceipt: true, onReceiptAdd: clickListener });
+    useReceiptSpy.mockReturnValue({ ...mockUseReceipt, cannotAddReceipt: true, onReceiptAdd: clickListener });
+    useSnackbarSpy.mockReturnValue(mockUseSnackbar);
     const { container } = render(<ClickAddReceiptDisabled />);
     await ClickAddReceiptDisabled.play({ canvasElement: container });
     expect(clickListener).not.toHaveBeenCalled();
@@ -50,7 +61,12 @@ describe('Receiptコンポーネント', () => {
   it('正しく入力されたレシートが1枚以上ある場合、「食費を登録」をクリックするとメソッドが呼ばれる', async () => {
     const mockOnClick = jest.fn();
     // TODO validateメソッドをカスタムフックから剥がせれば...
-    useReceiptSpy.mockReturnValue({ ...mockResponse, cannotRegistReceipt: false, validate: () => ({ isOk: true }) });
+    useReceiptSpy.mockReturnValue({
+      ...mockUseReceipt,
+      cannotRegistReceipt: false,
+      validate: () => ({ isOk: true, text: '', subText: '' }),
+    });
+    useSnackbarSpy.mockReturnValue(mockUseSnackbar);
     const { container } = render(<ClickRegist onClickRegist={mockOnClick} />);
     await ClickRegist.play({ canvasElement: container });
     expect(mockOnClick).toHaveBeenCalled();
@@ -58,7 +74,12 @@ describe('Receiptコンポーネント', () => {
   it('入力不備のレシートが1枚でもある場合、「食費を登録」をクリックしてもメソッドは呼ばれない', async () => {
     const mockOnClick = jest.fn();
     // TODO validateメソッドをカスタムフックから剥がせれば...
-    useReceiptSpy.mockReturnValue({ ...mockResponse, cannotRegistReceipt: true, validate: () => ({ isOk: false }) });
+    useReceiptSpy.mockReturnValue({
+      ...mockUseReceipt,
+      cannotRegistReceipt: true,
+      validate: () => ({ isOk: false, text: '', subText: '' }),
+    });
+    useSnackbarSpy.mockReturnValue(mockUseSnackbar);
     const { container } = render(<ClickRegistWithDefect onClickRegist={mockOnClick} />);
     await ClickRegistWithDefect.play({ canvasElement: container });
     expect(mockOnClick).not.toHaveBeenCalled();
@@ -66,14 +87,20 @@ describe('Receiptコンポーネント', () => {
   it('レシートが1枚もない場合、「食費を登録」をクリックしてもメソッドは呼ばれない', async () => {
     const mockOnClick = jest.fn();
     // TODO validateメソッドをカスタムフックから剥がせれば...
-    useReceiptSpy.mockReturnValue({ ...mockResponse, cannotRegistReceipt: true, validate: () => ({ isOk: false }) });
+    useReceiptSpy.mockReturnValue({
+      ...mockUseReceipt,
+      cannotRegistReceipt: true,
+      validate: () => ({ isOk: false, text: '', subText: '' }),
+    });
+    useSnackbarSpy.mockReturnValue(mockUseSnackbar);
     const { container } = render(<ClickRegistDisabled onClickRegist={mockOnClick} />);
     await ClickRegistDisabled.play({ canvasElement: container });
     expect(mockOnClick).not.toHaveBeenCalled();
   });
   it('レシートが1枚もない場合、「Noマネーデイとして登録」をクリックするとメソッドが呼ばれる', async () => {
     const mockOnClick = jest.fn();
-    useReceiptSpy.mockReturnValue({ ...mockResponse, cannotRegistNoMoney: false });
+    useReceiptSpy.mockReturnValue({ ...mockUseReceipt, cannotRegistNoMoney: false });
+    useSnackbarSpy.mockReturnValue(mockUseSnackbar);
     const { container } = render(<ClickNoMoney onClickNoMoney={mockOnClick} />);
     await ClickNoMoney.play({ canvasElement: container });
     expect(mockOnClick).toHaveBeenCalled();
@@ -81,7 +108,8 @@ describe('Receiptコンポーネント', () => {
   it('レシートが1枚でも存在する場合、「Noマネーデイとして登録」をクリックしてもメソッドは呼ばれない', async () => {
     const mockOnClick = jest.fn();
     // TODO validateメソッドをカスタムフックから剥がせれば...
-    useReceiptSpy.mockReturnValue({ ...mockResponse, cannotRegistNoMoney: true });
+    useReceiptSpy.mockReturnValue({ ...mockUseReceipt, cannotRegistNoMoney: true });
+    useSnackbarSpy.mockReturnValue(mockUseSnackbar);
     const { container } = render(<ClickNoMoneyDisabled onClickNoMoney={mockOnClick} />);
     await ClickNoMoneyDisabled.play({ canvasElement: container });
     expect(mockOnClick).not.toHaveBeenCalled();

--- a/src/components/receipt/Receipt.test.tsx
+++ b/src/components/receipt/Receipt.test.tsx
@@ -37,7 +37,7 @@ describe('Receiptコンポーネント', () => {
     type: 'success',
     text: '',
     subText: '',
-    setIsOpen: jest.fn(),
+    showSnackbar: jest.fn(),
     setSnackbarDetails: jest.fn(),
   };
   const useReceiptSpy = jest.spyOn({ useReceipt }, 'useReceipt');

--- a/src/components/receipt/Receipt.tsx
+++ b/src/components/receipt/Receipt.tsx
@@ -168,7 +168,7 @@ export const Receipt = ({ receipts, targetDate, onClickRegist, onClickNoMoney }:
           data-testid="btn-no-money"
         />
       </div>
-      <Snackbar open={isOpen} type={type} text={text} subText={subText} />
+      {isOpen && <Snackbar open={isOpen} type={type} text={text} subText={subText} />}
     </div>
   );
 };

--- a/src/components/receipt/Receipt.tsx
+++ b/src/components/receipt/Receipt.tsx
@@ -5,6 +5,8 @@ import { HiPlusSm } from 'react-icons/hi';
 import { Receipt as ReceiptDef } from '../../reducer/householdBookSlice';
 import { Button } from '../common/button/Button';
 import { Divider } from '../common/divider/Divider';
+import { Snackbar } from '../common/snackbar/Snackbar';
+import { useSnackbar } from '../common/snackbar/useSnackbar';
 import { Typography } from '../common/typography/Typography';
 import { Tag } from './tag/Tag';
 import { useReceipt } from './useReceipt';
@@ -25,18 +27,17 @@ export const Receipt = ({ receipts, targetDate, onClickRegist, onClickNoMoney }:
   const { t } = useTranslation();
   const {
     dailyReceipt,
-    snackbarStatus,
     calcSummartion,
     onReceiptAdd,
     onChangeStoreName,
     onChangeCost,
     onReceiptDelete,
-    showSnackbar,
     cannotAddReceipt,
     cannotRegistReceipt,
     cannotRegistNoMoney,
     validate,
   } = useReceipt(receipts);
+  const { isOpen, type, text, subText, setIsOpen, setSnackbarDetails } = useSnackbar();
 
   /**
    * レシートを追加する
@@ -72,30 +73,20 @@ export const Receipt = ({ receipts, targetDate, onClickRegist, onClickNoMoney }:
   };
 
   /**
-   * 処理が成功した時のスナックバーを表示する
-   */
-  const showSuccessSnackbar = (text: string, subText?: string) => {
-    showSnackbar({ open: true, type: 'success', text, subText });
-  };
-
-  /**
-   * 処理が失敗した時のスナックバーを表示する
-   */
-  const showErrorSnackbar = (text: string, subText?: string) => {
-    showSnackbar({ open: true, type: 'error', text, subText });
-  };
-
-  /**
    * [食費を登録]ボタンが押された場合の動作 <br/>
    * 編集日のデータが登録済みかに応じてPOST/PUTを投げ分ける
    *
    */
   const handleClickRegist = () => {
-    if (!validate().isOk) {
-      showErrorSnackbar(validate().text, validate().subText);
+    const validateResult = validate();
+    if (!validateResult.isOk) {
+      setSnackbarDetails('error', validateResult.text, validateResult.subText);
+      setIsOpen(true);
       return;
     }
+    setSnackbarDetails('success', validateResult.text, validateResult.subText);
     onClickRegist(dailyReceipt);
+    setIsOpen(true);
   };
 
   /**
@@ -177,7 +168,7 @@ export const Receipt = ({ receipts, targetDate, onClickRegist, onClickNoMoney }:
           data-testid="btn-no-money"
         />
       </div>
-      {/* <Snackbar {...snackbarStatus} /> */}
+      <Snackbar open={isOpen} type={type} text={text} subText={subText} />
     </div>
   );
 };

--- a/src/components/receipt/Receipt.tsx
+++ b/src/components/receipt/Receipt.tsx
@@ -96,6 +96,8 @@ export const Receipt = ({ receipts, targetDate, onClickRegist, onClickNoMoney }:
   const handleClickNoMoney = () => {
     // TODO テストできればこれ要らないか？
     onClickNoMoney();
+    setSnackbarDetails('success', t('calendar.registration_complete'), '');
+    showSnackbar();
   };
 
   return (

--- a/src/components/receipt/Receipt.tsx
+++ b/src/components/receipt/Receipt.tsx
@@ -37,7 +37,7 @@ export const Receipt = ({ receipts, targetDate, onClickRegist, onClickNoMoney }:
     cannotRegistNoMoney,
     validate,
   } = useReceipt(receipts);
-  const { isOpen, type, text, subText, setIsOpen, setSnackbarDetails } = useSnackbar();
+  const { isOpen, type, text, subText, showSnackbar, setSnackbarDetails } = useSnackbar();
 
   /**
    * レシートを追加する
@@ -81,12 +81,12 @@ export const Receipt = ({ receipts, targetDate, onClickRegist, onClickNoMoney }:
     const validateResult = validate();
     if (!validateResult.isOk) {
       setSnackbarDetails('error', validateResult.text, validateResult.subText);
-      setIsOpen(true);
+      showSnackbar();
       return;
     }
-    setSnackbarDetails('success', validateResult.text, validateResult.subText);
     onClickRegist(dailyReceipt);
-    setIsOpen(true);
+    setSnackbarDetails('success', validateResult.text, validateResult.subText);
+    showSnackbar();
   };
 
   /**

--- a/src/components/receipt/useReceipt.ts
+++ b/src/components/receipt/useReceipt.ts
@@ -41,11 +41,6 @@ export const useReceipt = (initReceipts: Receipt[] | [] | null): UseReceiptRetur
     [dailyReceipt]
   );
 
-  // const showSnackbar = useCallback((status: SnackbarProps) => {
-  //   setSnackbarStatus({ ...status });
-  //   setTimeout(() => setSnackbarStatus((current) => ({ ...current, open: false })), 2000);
-  // }, []);
-
   /**
    * 選択中の日付における合計金額を計算する
    * @returns 合計金額に￥マークをつけつつカンマ区切りにして返す

--- a/src/components/receipt/useReceipt.ts
+++ b/src/components/receipt/useReceipt.ts
@@ -106,13 +106,11 @@ export const useReceipt = (initReceipts: Receipt[] | [] | null): UseReceiptRetur
 
 export type UseReceiptReturnType = {
   dailyReceipt: Receipt[] | [];
-  // snackbarStatus: SnackbarProps;
   calcSummartion: () => string;
   onReceiptAdd: () => void;
   onChangeStoreName: (index: number, storeName: string) => void;
   onChangeCost: (index: number, cost: number) => void;
   onReceiptDelete: (ordinary: number) => void;
-  // showSnackbar: (status: SnackbarProps) => void;
   cannotAddReceipt: boolean;
   cannotRegistReceipt: boolean;
   cannotRegistNoMoney: boolean;

--- a/src/components/receipt/useReceipt.ts
+++ b/src/components/receipt/useReceipt.ts
@@ -1,17 +1,10 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { SnackbarProps } from '../common/snackbar/Snackbar';
 import { Receipt } from '../../reducer/householdBookSlice';
 
 export const useReceipt = (initReceipts: Receipt[] | [] | null): UseReceiptReturnType => {
   const { t } = useTranslation();
   const [dailyReceipt, setDailyReceipt] = useState<Receipt[] | [] | null>(initReceipts);
-  // TODO Receiptコンポーネントとは分離した方がよい、ぜったい
-  const [snackbarStatus, setSnackbarStatus] = useState<SnackbarProps>({
-    open: false,
-    type: 'success',
-    text: '',
-  });
 
   useEffect(() => {
     // useStateの初期値にpropsを指定しても初回描画時しか効かないのでuseEffectで変更させる
@@ -48,10 +41,10 @@ export const useReceipt = (initReceipts: Receipt[] | [] | null): UseReceiptRetur
     [dailyReceipt]
   );
 
-  const showSnackbar = useCallback((status: SnackbarProps) => {
-    setSnackbarStatus({ ...status });
-    setTimeout(() => setSnackbarStatus((current) => ({ ...current, open: false })), 2000);
-  }, []);
+  // const showSnackbar = useCallback((status: SnackbarProps) => {
+  //   setSnackbarStatus({ ...status });
+  //   setTimeout(() => setSnackbarStatus((current) => ({ ...current, open: false })), 2000);
+  // }, []);
 
   /**
    * 選択中の日付における合計金額を計算する
@@ -77,48 +70,33 @@ export const useReceipt = (initReceipts: Receipt[] | [] | null): UseReceiptRetur
    * @returns バリデーションの成否
    */
   const validate = () => {
-    const text = t('calendar.registration_imcomplete');
+    const invalidTemplate = {
+      isOk: false,
+      text: t('calendar.registration_imcomplete'),
+    };
     if (dailyReceipt?.filter((r) => r.cost === null).length > 0) {
-      return {
-        isOk: false,
-        text,
-        subText: t('calendar.expense_is_not_entered'),
-      };
+      return { ...invalidTemplate, subText: t('calendar.expense_is_not_entered') };
     }
     if (dailyReceipt?.filter((r) => r.storeName === '').length > 0) {
-      return {
-        isOk: false,
-        text,
-        subText: t('calendar.store_name_is_not_entered'),
-      };
+      return { ...invalidTemplate, subText: t('calendar.store_name_is_not_entered') };
     }
     if (dailyReceipt.filter((receipt) => Number.isNaN(receipt.cost)).length > 0) {
-      return {
-        isOk: false,
-        text,
-        subText: t('calendar.expense_is_not_number'),
-      };
+      return { ...invalidTemplate, subText: t('calendar.expense_is_not_number') };
     }
     const storeNames = dailyReceipt?.map((receipt) => receipt.storeName);
     if ([...new Set(storeNames)].length !== storeNames.length) {
-      return {
-        isOk: false,
-        text,
-        subText: t('calendar.exists_duplicate_receipts'),
-      };
+      return { ...invalidTemplate, subText: t('calendar.exists_duplicate_receipts') };
     }
-    return { isOk: true };
+    return { isOk: true, text: t('calendar.registration_complete'), subText: '' };
   };
 
   return {
     dailyReceipt,
-    snackbarStatus,
     calcSummartion,
     onReceiptAdd,
     onChangeStoreName,
     onChangeCost,
     onReceiptDelete,
-    showSnackbar,
     cannotAddReceipt,
     cannotRegistReceipt,
     cannotRegistNoMoney,
@@ -128,15 +106,15 @@ export const useReceipt = (initReceipts: Receipt[] | [] | null): UseReceiptRetur
 
 export type UseReceiptReturnType = {
   dailyReceipt: Receipt[] | [];
-  snackbarStatus: SnackbarProps;
+  // snackbarStatus: SnackbarProps;
   calcSummartion: () => string;
   onReceiptAdd: () => void;
   onChangeStoreName: (index: number, storeName: string) => void;
   onChangeCost: (index: number, cost: number) => void;
   onReceiptDelete: (ordinary: number) => void;
-  showSnackbar: (status: SnackbarProps) => void;
+  // showSnackbar: (status: SnackbarProps) => void;
   cannotAddReceipt: boolean;
   cannotRegistReceipt: boolean;
   cannotRegistNoMoney: boolean;
-  validate: () => { isOk: boolean; text: string; subText: string } | { isOk: boolean; text?: string; subText?: string };
+  validate: () => { isOk: boolean; text: string; subText: string };
 };


### PR DESCRIPTION
### 概要
`Receipt`のカスタムフック内にくっついていた`Snackbar`のロジックを別のカスタムフックとして切り出す

### 使い方
* Snackbarを表示したいコンポーネントでカスタムフック（`useSnackbar`）を定義
* 表示するタイミングと文言だけ指定すればOK、表示を消す処理はカスタムフック側が責任も持つ